### PR TITLE
[ feat ] 5 :  s3 이미지 기능 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -37,6 +37,9 @@ dependencies {
 
     //swagger 의존성
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
+
+    //S3 의존성
+    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/funding/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/controller/ProjectController.java
@@ -99,5 +99,4 @@ public class ProjectController {
 
 
 
-
 }

--- a/backend/src/main/java/com/funding/backend/domain/projectImage/entity/ProjectImage.java
+++ b/backend/src/main/java/com/funding/backend/domain/projectImage/entity/ProjectImage.java
@@ -38,11 +38,16 @@ public class ProjectImage extends Auditable {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
+    @Column
+    private String originalFilename;
+
+    @Column
+    private String storedFileName;
+
 
     @ManyToOne
     @JoinColumn(name = "project_id",nullable = false)
     private Project project;
-
 
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/projectImage/repository/ProjectImageRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/projectImage/repository/ProjectImageRepository.java
@@ -1,0 +1,7 @@
+package com.funding.backend.domain.projectImage.repository;
+
+import com.funding.backend.domain.projectImage.entity.ProjectImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectImageRepository extends JpaRepository<ProjectImage,Long> {
+}

--- a/backend/src/main/java/com/funding/backend/global/config/AwsS3Config.java
+++ b/backend/src/main/java/com/funding/backend/global/config/AwsS3Config.java
@@ -1,0 +1,33 @@
+package com.funding.backend.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class AwsS3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+ 
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+ 
+    @Value("${cloud.aws.region.static}")
+    private String region;
+ 
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -10,6 +10,10 @@ public enum ExceptionCode {
     //구매 예외처리
     PURCHASE_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 입니다. "),
 
+    //S3 예외 처리
+    S3_DELETE_ERROR(404, "이미지를 삭제할 수 없습니다."),
+    IMAGE_NOT_FOUND(404,"이미지를 찾을 수 없습니다."),
+
 
 
     //요금제 예외 처리

--- a/backend/src/main/java/com/funding/backend/global/utils/CreateRandomNumber.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/CreateRandomNumber.java
@@ -1,0 +1,37 @@
+package com.funding.backend.global.utils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+public class CreateRandomNumber {
+
+    private static final Random random = new Random();
+
+    public static String randomNumber(){
+        return UUID.randomUUID().toString().substring(0, 10);
+    }
+
+    public static String randomNumberSix() {
+        Random random = new Random();
+        int number = 100000 + random.nextInt(900000); // 100000 ~ 999999
+        return String.valueOf(number);
+    }
+
+
+    //날짜 + 시간 + 랜덤번호
+    public static String timeBasedRandomName() {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        String uuidPart = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+        return timestamp + "_" + uuidPart;
+    }
+
+    public static <T> T randomFromList(List<T> list) {
+        if (list == null || list.isEmpty()) {
+            throw new IllegalArgumentException("List cannot be null or empty");
+        }
+        return list.get(random.nextInt(list.size()));
+    }
+}

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
@@ -63,15 +63,23 @@ public class ImageService {
     public List<ProjectImage> updateImageList(List<ProjectImage> beforeImages, List<MultipartFile> newImages, Project project) {
         List<ProjectImage> updated = s3Uploader.autoImagesUploadAndDelete(beforeImages, newImages, project);
 
-        // DB에 새로 추가된 건 저장
+        // 새로 추가된 이미지 저장
         for (ProjectImage image : updated) {
             if (image.getId() == null) {
                 projectImageRepository.save(image);
             }
         }
 
+        // 삭제된 이미지 DB에서도 제거
+        for (ProjectImage oldImage : beforeImages) {
+            if (!updated.contains(oldImage)) {
+                projectImageRepository.delete(oldImage);
+            }
+        }
+
         return updated;
     }
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
@@ -2,7 +2,9 @@ package com.funding.backend.global.utils.s3;
 
 
 
+import com.funding.backend.domain.projectImage.entity.ProjectImage;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +30,20 @@ public class ImageService {
 
     public void deleteImage(String fileName){
         s3Uploader.deleteFile(fileName);
+    }
+
+
+    //이미지 여러개 저장
+    public List<String> saveImageList(List<MultipartFile> images){
+        try {
+            return s3Uploader.saveMultiImages(images); // 업로드 후 URL 반환
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void updateImageList(List<ProjectImage> beforeImages, List<MultipartFile> images){
+
     }
 
 

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
@@ -26,8 +26,6 @@ public class ImageService {
         return saveImage(multipartFile);
     }
 
-
-
     public void deleteImage(String fileName){
         s3Uploader.deleteFile(fileName);
     }

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
@@ -2,8 +2,11 @@ package com.funding.backend.global.utils.s3;
 
 
 
+import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.projectImage.entity.ProjectImage;
+import com.funding.backend.domain.projectImage.repository.ProjectImageRepository;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImageService {
 
     private final S3Uploader s3Uploader;
+    private final ProjectImageRepository projectImageRepository;
 
     public String saveImage(MultipartFile multipartFile){
         try {
@@ -33,18 +37,42 @@ public class ImageService {
     }
 
 
-    //이미지 여러개 저장
-    public List<String> saveImageList(List<MultipartFile> images){
-        try {
-            return s3Uploader.saveMultiImages(images); // 업로드 후 URL 반환
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+    public List<ProjectImage> saveImageList(List<MultipartFile> images, Project project) {
+        List<ProjectImage> savedList = new ArrayList<>();
+        for (MultipartFile image : images) {
+            try {
+                String url = s3Uploader.uploadFile(image);
+                String storedName = url.substring(url.lastIndexOf("/") + 1);
+
+                ProjectImage pi = ProjectImage.builder()
+                        .imageUrl(url)
+                        .storedFileName(storedName)
+                        .originalFilename(image.getOriginalFilename())
+                        .project(project)
+                        .build();
+
+                savedList.add(projectImageRepository.save(pi));
+            } catch (IOException e) {
+                throw new RuntimeException("이미지 업로드 실패", e);
+            }
         }
+        return savedList;
     }
 
-    public void updateImageList(List<ProjectImage> beforeImages, List<MultipartFile> images){
 
+    public List<ProjectImage> updateImageList(List<ProjectImage> beforeImages, List<MultipartFile> newImages, Project project) {
+        List<ProjectImage> updated = s3Uploader.autoImagesUploadAndDelete(beforeImages, newImages, project);
+
+        // DB에 새로 추가된 건 저장
+        for (ProjectImage image : updated) {
+            if (image.getId() == null) {
+                projectImageRepository.save(image);
+            }
+        }
+
+        return updated;
     }
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
@@ -1,0 +1,37 @@
+package com.funding.backend.global.utils.s3;
+
+
+
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Uploader s3Uploader;
+
+    public String saveImage(MultipartFile multipartFile){
+        try {
+            return s3Uploader.uploadFile(multipartFile); // 업로드 후 URL 반환
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String updateImage(MultipartFile multipartFile,String beforeImageUrl){
+        deleteImage(beforeImageUrl);
+        return saveImage(multipartFile);
+    }
+
+
+
+    public void deleteImage(String fileName){
+        s3Uploader.deleteFile(fileName);
+    }
+
+
+
+}

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
@@ -1,0 +1,96 @@
+package com.funding.backend.global.utils.s3;
+
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.utils.CreateRandomNumber;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Uploader {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+
+    // S3에 이미지 등록
+    public String uploadFile(MultipartFile multipartFile) throws IOException {
+        String fileName = multipartFile.getOriginalFilename();
+
+        //파일 형식 구하기
+        String ext = fileName.split("\\.")[1];
+        log.info("fileName 확인 !!" + fileName);
+        log.info("파일 형식 확인 !! " + ext);
+
+        // 랜덤한 UUID를 이용한 고유 파일명 생성
+        String uniqueFileName = CreateRandomNumber.timeBasedRandomName() + "." + ext;
+
+        String contentType = "";
+
+        //content type을 지정해서 올려주지 않으면 자동으로 "application/octet-stream"으로 고정이 되서 링크 클릭시 웹에서 열리는게 아니라 자동 다운이 시작됨.
+        switch (ext) {
+            case "jpeg":
+                contentType = "image/jpeg";
+                break;
+            case "png":
+                contentType = "image/png";
+                break;
+            case "txt":
+                contentType = "text/plain";
+                break;
+            case "csv":
+                contentType = "text/csv";
+                break;
+        }
+
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(contentType);
+
+            //S3에 파일 업로드
+            amazonS3.putObject(new PutObjectRequest(bucket, uniqueFileName, multipartFile.getInputStream(), metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (AmazonServiceException e) {
+            e.printStackTrace();
+        } catch (SdkClientException e) {
+            e.printStackTrace();
+        }
+
+//        //object 정보 가져오기 (디버깅용) 데이터 잘 들어갔는지 확인하려고
+//        ListObjectsV2Result listObjectsV2Result = amazonS3.listObjectsV2(bucket);
+//        List<S3ObjectSummary> objectSummaries = listObjectsV2Result.getObjectSummaries();
+//
+//        for (S3ObjectSummary object: objectSummaries) {
+//            log.info("object = " + object.toString());
+//        }
+        return amazonS3.getUrl(bucket, uniqueFileName).toString();
+    }
+
+    // S3에 이미지 삭제
+    public void deleteFile(String imageUrl) {
+        try {
+            String key = imageUrl.contains(".com/") ? imageUrl.split(".com/")[1] : imageUrl;
+            amazonS3.deleteObject(bucket, key);
+
+        } catch (AmazonServiceException e) {
+           // System.err.println(e.getErrorMessage());
+        } catch (Exception exception) {
+            throw new BusinessLogicException(ExceptionCode.S3_DELETE_ERROR);
+        }
+    }
+
+}

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
@@ -50,23 +50,15 @@ public class S3Uploader {
         // 랜덤한 UUID를 이용한 고유 파일명 생성
         String uniqueFileName = CreateRandomNumber.timeBasedRandomName() + "." + ext;
 
-        String contentType = "";
 
-        //content type을 지정해서 올려주지 않으면 자동으로 "application/octet-stream"으로 고정이 되서 링크 클릭시 웹에서 열리는게 아니라 자동 다운이 시작됨.
-        switch (ext) {
-            case "jpeg":
-                contentType = "image/jpeg";
-                break;
-            case "png":
-                contentType = "image/png";
-                break;
-            case "txt":
-                contentType = "text/plain";
-                break;
-            case "csv":
-                contentType = "text/csv";
-                break;
-        }
+
+        String contentType = switch (ext) {
+            case "jpeg", "jpg" -> "image/jpeg";
+            case "png" -> "image/png";
+            case "txt" -> "text/plain";
+            case "csv" -> "text/csv";
+            default -> "application/octet-stream";
+        };
 
         try {
             ObjectMetadata metadata = new ObjectMetadata();

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.global.utils.CreateRandomNumber;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
@@ -83,15 +83,6 @@ public class S3Uploader {
         return amazonS3.getUrl(bucket, uniqueFileName).toString();
     }
 
-    //이미지 리스트 저장
-    public List<String> saveMultiImages(List<MultipartFile> multipartFileList) throws IOException {
-        List<String> imageUrl = new ArrayList<>();
-        for(MultipartFile image : multipartFileList){
-            imageUrl.add(uploadFile(image));
-        }
-
-        return imageUrl;
-    }
 
 
     // S3에 이미지 삭제


### PR DESCRIPTION
## 📒 개요

이미지 기능 구현 

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#5 
> closed #Issue_number

<br>

## 🛠️ 작업사항

## 🔧 S3 이미지 처리 기능 구현

### ✅ 1. 단일 이미지 업로드
```java
uploadFile(MultipartFile file)
```
- 고유한 UUID 기반 파일명으로 S3에 저장  
- Content-Type 지정 (`image/png`, `image/jpeg`, 등)  
- 업로드된 이미지의 **public URL 반환**

---

### ✅ 2. 다중 이미지 업로드
```java
saveImageList(List<MultipartFile> images, Project project)
```
- 여러 이미지를 순회하며 S3에 업로드  
- 각 이미지의 URL 리스트 반환

---

### ✅ 3. 이미지 삭제
```java
deleteFile(String storedFileName)
```
- 파일명을 기준으로 S3에서 이미지 삭제

---

### ✅ 4. 이미지 수정 (업로드 + 삭제 자동 처리)
```java
autoImagesUploadAndDelete(
    List<ProjectImage> beforeImages,
    List<MultipartFile> newImages,
    Project project
)
```
- 기존 이미지 목록과 새 이미지 비교하여:
  - ➕ **새로 들어온 이미지만 업로드**
  - ➖ **제거된 이미지만 S3에서 삭제**
- 최종적으로 **남아있는 이미지 + 새 이미지 리스트 반환**

---

### ✅ 5. 이미지 DB 저장 로직 연결
- S3에 업로드 후, 해당 이미지 URL 및 원본/저장 이름을 `ProjectImage` 엔티티로 DB에 저장  
- 수정 시 `ID == null`인 새 이미지만 `projectImageRepository.save()` 수행
- 원본 이미지 이름이 아닌 UUID로 저장함으로써, 중복 이미지 저장 방지


<br>

## 📸 스크린샷(선택)
