### PR TITLE
[ feat] 17 : 공지사항 기능 구현

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
@@ -8,6 +8,7 @@ import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,7 +33,7 @@ public class NoticeController {
             @RequestBody NoticeCreateRequestDto noticeCreateRequestDto) {
 
         NoticeReseponseDto noticeResponse = noticeService.createNotice(/* loginUserId, */projectId, noticeCreateRequestDto);
-        return ResponseEntity.ok(ApiResponse.of(201, "공지사항 생성 성공", noticeResponse));
+        return ResponseEntity.ok(ApiResponse.of(HttpStatus.CREATED.value(), "공지사항 생성 성공", noticeResponse));
     }
 
     // TODO: 추후 회원 기능 개발 시 주석 해제
@@ -48,6 +49,20 @@ public class NoticeController {
             @RequestBody NoticeUpdateRequestDto noticeUpdateRequestDto) {
 
         NoticeReseponseDto noticeResponse = noticeService.updateNotice(/* loginUserId, */noticeId, noticeUpdateRequestDto);
-        return ResponseEntity.ok(ApiResponse.of(200, "공지사항 수정 성공", noticeResponse));
+        return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK.value(), "공지사항 수정 성공", noticeResponse));
+    }
+
+    // TODO: 추후 회원 기능 개발 시 주석 해제
+    @Operation(
+            summary = "공지사항 삭제",
+            description = "프로젝트 생성자가 공지사항을 삭제합니다."
+    )
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteNotice(
+            /* Long loginUserId, */
+            @PathVariable Long noticeId) {
+
+        noticeService.deleteNotice(/* loginUserId, */noticeId);
+        return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK.value(), "공지사항 삭제 성공"));
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
@@ -29,13 +29,12 @@ public class NoticeController {
             description = "프로젝트 생성자가 공지사항을 생성합니다."
 //            security = @SecurityRequirement(name = "JWT")
     )
-    @PostMapping("/{projectId}")
+    @PostMapping
     public ResponseEntity<ApiResponse<NoticeReseponseDto>> createNotice(
             /* Long loginUserId, */
-            @PathVariable Long projectId,
             @RequestBody @Valid NoticeCreateRequestDto noticeCreateRequestDto) {
 
-        NoticeReseponseDto noticeResponse = noticeService.createNotice(/* loginUserId, */projectId, noticeCreateRequestDto);
+        NoticeReseponseDto noticeResponse = noticeService.createNotice(/* loginUserId, */noticeCreateRequestDto);
         return ResponseEntity.ok(ApiResponse.of(HttpStatus.CREATED.value(), "공지사항 생성 성공", noticeResponse));
     }
 

--- a/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
@@ -1,0 +1,36 @@
+package com.funding.backend.domain.notice.controller;
+
+import com.funding.backend.domain.notice.dto.request.NoticeCreateRequestDto;
+import com.funding.backend.domain.notice.dto.response.NoticeReseponseDto;
+import com.funding.backend.domain.notice.service.NoticeService;
+import com.funding.backend.global.utils.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/notice")
+@RequiredArgsConstructor
+@Tag(name = "공지사항 관리 API", description = "공지사항 관련 API 입니다.")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    // TODO: 추후 회원 기능 개발 시 주석 해제
+    @Operation(
+            summary = "공지사항 생성",
+            description = "프로젝트 생성자가 공지사항을 생성합니다."
+//            security = @SecurityRequirement(name = "JWT")
+    )
+    @PostMapping("/{projectId}")
+    public ResponseEntity<ApiResponse<NoticeReseponseDto>> createNotice(
+            /* Long loginUserId, */
+            @PathVariable Long projectId,
+            @RequestBody NoticeCreateRequestDto noticeCreateRequestDto) {
+
+        NoticeReseponseDto noticeResponse = noticeService.createNotice(/* loginUserId, */projectId, noticeCreateRequestDto);
+        return ResponseEntity.ok(ApiResponse.of(201, "공지사항 생성 성공", noticeResponse));
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
@@ -1,6 +1,7 @@
 package com.funding.backend.domain.notice.controller;
 
 import com.funding.backend.domain.notice.dto.request.NoticeCreateRequestDto;
+import com.funding.backend.domain.notice.dto.request.NoticeUpdateRequestDto;
 import com.funding.backend.domain.notice.dto.response.NoticeReseponseDto;
 import com.funding.backend.domain.notice.service.NoticeService;
 import com.funding.backend.global.utils.ApiResponse;
@@ -32,5 +33,21 @@ public class NoticeController {
 
         NoticeReseponseDto noticeResponse = noticeService.createNotice(/* loginUserId, */projectId, noticeCreateRequestDto);
         return ResponseEntity.ok(ApiResponse.of(201, "공지사항 생성 성공", noticeResponse));
+    }
+
+    // TODO: 추후 회원 기능 개발 시 주석 해제
+    @Operation(
+            summary = "공지사항 수정",
+            description = "프로젝트 생성자가 공지사항을 수정합니다."
+//            security = @SecurityRequirement(name = "JWT")
+    )
+    @PutMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<NoticeReseponseDto>> updateNotice(
+            /* Long loginUserId, */
+            @PathVariable Long noticeId,
+            @RequestBody NoticeUpdateRequestDto noticeUpdateRequestDto) {
+
+        NoticeReseponseDto noticeResponse = noticeService.updateNotice(/* loginUserId, */noticeId, noticeUpdateRequestDto);
+        return ResponseEntity.ok(ApiResponse.of(200, "공지사항 수정 성공", noticeResponse));
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/controller/NoticeController.java
@@ -7,10 +7,13 @@ import com.funding.backend.domain.notice.service.NoticeService;
 import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/notice")
@@ -30,7 +33,7 @@ public class NoticeController {
     public ResponseEntity<ApiResponse<NoticeReseponseDto>> createNotice(
             /* Long loginUserId, */
             @PathVariable Long projectId,
-            @RequestBody NoticeCreateRequestDto noticeCreateRequestDto) {
+            @RequestBody @Valid NoticeCreateRequestDto noticeCreateRequestDto) {
 
         NoticeReseponseDto noticeResponse = noticeService.createNotice(/* loginUserId, */projectId, noticeCreateRequestDto);
         return ResponseEntity.ok(ApiResponse.of(HttpStatus.CREATED.value(), "공지사항 생성 성공", noticeResponse));
@@ -46,7 +49,7 @@ public class NoticeController {
     public ResponseEntity<ApiResponse<NoticeReseponseDto>> updateNotice(
             /* Long loginUserId, */
             @PathVariable Long noticeId,
-            @RequestBody NoticeUpdateRequestDto noticeUpdateRequestDto) {
+            @RequestBody @Valid NoticeUpdateRequestDto noticeUpdateRequestDto) {
 
         NoticeReseponseDto noticeResponse = noticeService.updateNotice(/* loginUserId, */noticeId, noticeUpdateRequestDto);
         return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK.value(), "공지사항 수정 성공", noticeResponse));
@@ -56,6 +59,7 @@ public class NoticeController {
     @Operation(
             summary = "공지사항 삭제",
             description = "프로젝트 생성자가 공지사항을 삭제합니다."
+//            security = @SecurityRequirement(name = "JWT")
     )
     @DeleteMapping("/{noticeId}")
     public ResponseEntity<ApiResponse<Void>> deleteNotice(
@@ -64,5 +68,17 @@ public class NoticeController {
 
         noticeService.deleteNotice(/* loginUserId, */noticeId);
         return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK.value(), "공지사항 삭제 성공"));
+    }
+
+    @Operation(
+            summary = "프로젝트의 공지사항 전체 조회",
+            description = "특정 프로젝트의 모든 공지사항을 조회합니다."
+    )
+    @GetMapping("/project/{projectId}")
+    public ResponseEntity<ApiResponse<List<NoticeReseponseDto>>> getNoticesByProjectId(
+            @PathVariable Long projectId) {
+
+        List<NoticeReseponseDto> noticeResponses = noticeService.findNoticesByProjectId(projectId);
+        return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK.value(), "공지사항 전체 조회 성공", noticeResponses));
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeCreateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeCreateRequestDto.java
@@ -1,0 +1,23 @@
+package com.funding.backend.domain.notice.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+@Schema(name = "Notice Create Request DTO", description = "공지사항 생성 DTO")
+public class NoticeCreateRequestDto {
+
+    // TODO: 공지사항 제목 제한 길이 결정
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 100, message = "제목은 100자 이내여야 합니다.")
+    @Schema(description = "공지사항 제목", example = "펀딩 결제 안내")
+    private String title;
+
+    // TODO: 공지사항 내용 제한 길이 결정
+    @NotBlank(message = "내용은 필수입니다.")
+    @Size(max = 1000, message = "내용은 1000자 이내여야 합니다.")
+    @Schema(description = "공지사항 내용", example = "결제는 오후 6시에 진행됩니다.")
+    private String content;
+}

--- a/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeCreateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeCreateRequestDto.java
@@ -9,6 +9,10 @@ import lombok.Getter;
 @Schema(name = "Notice Create Request DTO", description = "공지사항 생성 DTO")
 public class NoticeCreateRequestDto {
 
+    @NotBlank(message = "프로젝트 ID는 필수입니다.")
+    @Schema(description = "프로젝트 ID", example = "1")
+    private Long projectId;
+
     @NotBlank(message = "제목은 필수입니다.")
     @Size(max = 100, message = "제목은 100자 이내여야 합니다.")
     @Schema(description = "공지사항 제목", example = "펀딩 결제 안내")

--- a/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeCreateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeCreateRequestDto.java
@@ -9,13 +9,11 @@ import lombok.Getter;
 @Schema(name = "Notice Create Request DTO", description = "공지사항 생성 DTO")
 public class NoticeCreateRequestDto {
 
-    // TODO: 공지사항 제목 제한 길이 결정
     @NotBlank(message = "제목은 필수입니다.")
     @Size(max = 100, message = "제목은 100자 이내여야 합니다.")
     @Schema(description = "공지사항 제목", example = "펀딩 결제 안내")
     private String title;
 
-    // TODO: 공지사항 내용 제한 길이 결정
     @NotBlank(message = "내용은 필수입니다.")
     @Size(max = 1000, message = "내용은 1000자 이내여야 합니다.")
     @Schema(description = "공지사항 내용", example = "결제는 오후 6시에 진행됩니다.")

--- a/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeRequestDto.java
@@ -1,4 +1,0 @@
-package com.funding.backend.domain.notice.dto.request;
-
-public class NoticeRequestDto {
-}

--- a/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
@@ -8,8 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Schema(name = "Notice Update Request DTO", description = "공지사항 수정 DTO")
 public class NoticeUpdateRequestDto {
 
     @NotBlank(message = "제목은 필수입니다.")

--- a/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
@@ -1,0 +1,21 @@
+package com.funding.backend.domain.notice.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeUpdateRequestDto {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    @Schema(description = "공지사항 제목", example = "수정된 공지사항 제목")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    @Schema(description = "공지사항 내용", example = "수정된 공지사항 내용")
+    private String content;
+}

--- a/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
@@ -2,6 +2,7 @@ package com.funding.backend.domain.notice.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +13,12 @@ import lombok.NoArgsConstructor;
 public class NoticeUpdateRequestDto {
 
     @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 100, message = "제목은 100자 이내여야 합니다.")
     @Schema(description = "공지사항 제목", example = "수정된 공지사항 제목")
     private String title;
 
     @NotBlank(message = "내용은 필수입니다.")
+    @Size(max = 1000, message = "내용은 1000자 이내여야 합니다.")
     @Schema(description = "공지사항 내용", example = "수정된 공지사항 내용")
     private String content;
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/dto/response/NoticeReseponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/dto/response/NoticeReseponseDto.java
@@ -1,4 +1,30 @@
 package com.funding.backend.domain.notice.dto.response;
 
+import com.funding.backend.domain.notice.entity.Notice;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(name = "Notice Response DTO", description = "공지사항 응답 DTO")
 public class NoticeReseponseDto {
+    @Schema(description = "공지사항 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "공지사항 제목", example = "펀딩 결제 안내")
+    private String noticeTitle;
+
+    @Schema(description = "공지사항 내용", example = "결제는 오후 6시에 진행됩니다.")
+    private String noticeContent;
+
+    @Schema(description = "생성일", example = "2025-07-15T14:25:14.293Z")
+    private LocalDateTime createdAt;
+
+    public NoticeReseponseDto(Notice notice) {
+        this.id = notice.getId();
+        this.noticeTitle = notice.getTitle();
+        this.noticeContent = notice.getContent();
+        this.createdAt = notice.getCreatedAt();
+    }
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/dto/response/NoticeReseponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/dto/response/NoticeReseponseDto.java
@@ -21,10 +21,14 @@ public class NoticeReseponseDto {
     @Schema(description = "생성일", example = "2025-07-15T14:25:14.293Z")
     private LocalDateTime createdAt;
 
+    @Schema(description = "수정일", example = "2025-07-16T14:25:14.293Z")
+    private LocalDateTime modifiedAt;
+
     public NoticeReseponseDto(Notice notice) {
         this.id = notice.getId();
         this.noticeTitle = notice.getTitle();
         this.noticeContent = notice.getContent();
         this.createdAt = notice.getCreatedAt();
+        this.modifiedAt = notice.getModifiedAt();
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/entity/Notice.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/entity/Notice.java
@@ -20,7 +20,6 @@ import lombok.experimental.SuperBuilder;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@SuperBuilder
 public class Notice extends Auditable {
 
     @Id

--- a/backend/src/main/java/com/funding/backend/domain/notice/entity/Notice.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/entity/Notice.java
@@ -36,4 +36,9 @@ public class Notice extends Auditable {
 
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/entity/Notice.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/entity/Notice.java
@@ -11,16 +11,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "notices")
 @Getter
-@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
@@ -34,9 +31,9 @@ public class Notice extends Auditable {
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
 
-    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
-    private String content;
-
     @Column(name = "title", length = 100, nullable = false)
     private String title;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/repository/NoticeRepository.java
@@ -1,9 +1,13 @@
 package com.funding.backend.domain.notice.repository;
 
 import com.funding.backend.domain.notice.entity.Notice;
+import com.funding.backend.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice,Long> {
+    List<Notice> findByProjectOrderByCreatedAtDesc(Project project);
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
@@ -1,11 +1,14 @@
 package com.funding.backend.domain.notice.service;
 
 import com.funding.backend.domain.notice.dto.request.NoticeCreateRequestDto;
+import com.funding.backend.domain.notice.dto.request.NoticeUpdateRequestDto;
 import com.funding.backend.domain.notice.dto.response.NoticeReseponseDto;
 import com.funding.backend.domain.notice.entity.Notice;
 import com.funding.backend.domain.notice.repository.NoticeRepository;
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.project.service.ProjectService;
+import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,8 +27,8 @@ public class NoticeService {
      *
      * @param loginUserId 로그인한 사용자 ID (회원 기능 개발 시 주석 해제)
      * @param projectId 프로젝트 ID
-     * @param noticeCreateRequestDto   공지사항 생성 요청용 DTO
-     * @return 생성된 공지사항 응답용 DTO
+     * @param noticeCreateRequestDto   생성할 공지사항 정보
+     * @return 생성된 공지사항 정보
      */
     @Transactional
     public NoticeReseponseDto createNotice(/* Long loginUserId, */Long projectId, NoticeCreateRequestDto noticeCreateRequestDto) {
@@ -44,6 +47,40 @@ public class NoticeService {
         Notice savedNotice = noticeRepository.save(notice);
 
         return new NoticeReseponseDto(savedNotice);
+    }
+
+    // TODO: 추후 회원 기능 개발 시 주석 해제
+    /**
+     * 공지사항을 수정합니다.
+     *
+     * @param loginUserId 로그인한 사용자 ID (회원 기능 개발 시 주석 해제)
+     * @param noticeId 공지사항 ID
+     * @param noticeUpdateRequestDto   수정할 공지사항 정보
+     * @return 수정된 공지사항 정보
+     */
+    @Transactional
+    public NoticeReseponseDto updateNotice(/* Long loginUserId, */Long noticeId, NoticeUpdateRequestDto noticeUpdateRequestDto) {
+
+        Notice notice = findNoticeById(noticeId);
+//        User loginUser = userService.findUserById(loginUserId);
+
+//        projectService.validProjectUser(notice.getProject().getUser(), loginUser);
+
+        notice.update(noticeUpdateRequestDto.getTitle(), noticeUpdateRequestDto.getContent());
+
+        return new NoticeReseponseDto(notice);
+    }
+
+
+    /**
+     * 공지사항 ID를 기준으로 공지사항을 조회합니다.
+     *
+     * @param noticeId 공지사항 ID
+     * @return 조회된 공지사항 엔티티
+     */
+    public Notice findNoticeById(Long noticeId) {
+        return noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOTICE_NOT_FOUND));
     }
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
@@ -33,9 +33,9 @@ public class NoticeService {
      * @return 생성된 공지사항 정보
      */
     @Transactional
-    public NoticeReseponseDto createNotice(/* Long loginUserId, */Long projectId, NoticeCreateRequestDto noticeCreateRequestDto) {
+    public NoticeReseponseDto createNotice(/* Long loginUserId, */NoticeCreateRequestDto noticeCreateRequestDto) {
 
-        Project project = projectService.findProjectById(projectId);
+        Project project = projectService.findProjectById(noticeCreateRequestDto.getProjectId());
 //        User loginUser = userService.findUserById(loginUserId);
 
 //        projectService.validProjectUser(project.getUser(), loginUser);
@@ -73,6 +73,7 @@ public class NoticeService {
         return new NoticeReseponseDto(notice);
     }
 
+    // TODO: 추후 회원 기능 개발 시 주석 해제
     @Transactional
     /**
      * 공지사항을 삭제합니다.

--- a/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
@@ -1,0 +1,49 @@
+package com.funding.backend.domain.notice.service;
+
+import com.funding.backend.domain.notice.dto.request.NoticeCreateRequestDto;
+import com.funding.backend.domain.notice.dto.response.NoticeReseponseDto;
+import com.funding.backend.domain.notice.entity.Notice;
+import com.funding.backend.domain.notice.repository.NoticeRepository;
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.project.service.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final ProjectService projectService;
+
+    // TODO: 추후 회원 기능 개발 시 주석 해제
+    /**
+     * 공지사항을 생성합니다.
+     *
+     * @param loginUserId 로그인한 사용자 ID (회원 기능 개발 시 주석 해제)
+     * @param projectId 프로젝트 ID
+     * @param noticeCreateRequestDto   공지사항 생성 요청용 DTO
+     * @return 생성된 공지사항 응답용 DTO
+     */
+    @Transactional
+    public NoticeReseponseDto createNotice(/* Long loginUserId, */Long projectId, NoticeCreateRequestDto noticeCreateRequestDto) {
+
+        Project project = projectService.findProjectById(projectId);
+//        User loginUser = userService.findUserById(loginUserId);
+
+//        projectService.validProjectUser(project.getUser(), loginUser);
+
+        Notice notice = Notice.builder()
+                .title(noticeCreateRequestDto.getTitle())
+                .content(noticeCreateRequestDto.getContent())
+                .project(project)
+                .build();
+
+        Notice savedNotice = noticeRepository.save(notice);
+
+        return new NoticeReseponseDto(savedNotice);
+    }
+
+}

--- a/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
@@ -71,6 +71,22 @@ public class NoticeService {
         return new NoticeReseponseDto(notice);
     }
 
+    @Transactional
+    /**
+     * 공지사항을 삭제합니다.
+     *
+     * @param noticeId 공지사항 ID
+     */
+    public void deleteNotice(/* Long loginUserId, */Long noticeId) {
+
+//        User loginUser = userService.findUserById(loginUserId);
+//
+//        projectService.validProjectUser(notice.getProject().getUser(), loginUser);
+
+        Notice notice = findNoticeById(noticeId);
+        noticeRepository.delete(notice);
+    }
+
 
     /**
      * 공지사항 ID를 기준으로 공지사항을 조회합니다.

--- a/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/funding/backend/domain/notice/service/NoticeService.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -87,6 +89,19 @@ public class NoticeService {
         noticeRepository.delete(notice);
     }
 
+    /**
+     * 특정 프로젝트의 모든 공지사항을 조회합니다.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 해당 프로젝트의 공지사항 목록
+     */
+    public List<NoticeReseponseDto> findNoticesByProjectId(Long projectId) {
+        Project project = projectService.findProjectById(projectId);
+        List<Notice> notices = noticeRepository.findByProjectOrderByCreatedAtDesc(project);
+        return notices.stream()
+                .map(NoticeReseponseDto::new)
+                .toList();
+    }
 
     /**
      * 공지사항 ID를 기준으로 공지사항을 조회합니다.

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -7,6 +7,9 @@ public enum ExceptionCode {
     PROJECT_NOT_FOUND(404,"존재하지 않는 프로젝트 입니다."),
     NOT_PROJECT_CREATOR(403, "해당 프로젝트의 생성자가 아닙니다."),
 
+    //공지사항 예외 처리
+    NOTICE_NOT_FOUND(404, "존재하지 않는 공지사항 입니다."),
+
     //구매 예외처리
     PURCHASE_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 입니다. "),
 


### PR DESCRIPTION
## 📒 개요

프로젝트의 공지사항 CRUD 기능 구현

<br>

## 📍 Issue 번호

- #17 

<br>

## 🛠️ 작업사항

### API Endpoints
- POST /api/v1/notice: 새로운 공지사항을 등록합니다.
- PUT /api/v1/notice/{noticeId}: 기존 공지사항을 수정합니다.
- DELETE /api/v1/notice/{noticeId}: 공지사항을 삭제합니다.
- GET /api/v1/notice/project/{projectId}: 특정 프로젝트의 공지사항들을 조회합니다.
     
### Exception
- notice id 기준으로 공지사항 조회 시, 해당 id의 공지사항이 없다면 나타낼 Exception Status 추가
```java
public enum ExceptionCode {
    ...
    NOTICE_NOT_FOUND(404, "존재하지 않는 공지사항 입니다."),
    ...
}
```

<br>

## ⚠️ 연결될 이후 이슈 작업사항
> 아직 회원 기능 개발 전이라 프로젝트 작성자인지 확인하는 기능 적용하지 않음.<br>추후 회원 기능 개발 후 프로젝트 작성자 확인 기능 주석 해제 필요
