### PR TITLE
[ feat ] 26 : 구매 옵션 기능 구현 crud, 구매 프로젝트 생성 방식 수정

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/controller/ProjectController.java
@@ -1,31 +1,19 @@
 package com.funding.backend.domain.project.controller;
 
 
-import com.funding.backend.domain.donation.dto.response.DonationProjectResponseDto;
-import com.funding.backend.domain.project.dto.request.ProjectCreateRequestDto;
 import com.funding.backend.domain.project.dto.response.ProjectResponseDto;
-import com.funding.backend.domain.project.dto.response.PurchaseProjectResponseDto;
 import com.funding.backend.domain.project.service.ProjectService;
 import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/backend/src/main/java/com/funding/backend/domain/project/dto/request/ProjectCreateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/dto/request/ProjectCreateRequestDto.java
@@ -48,6 +48,9 @@ public class ProjectCreateRequestDto {
     //이미지
     private List<MultipartFile> contentImage = new ArrayList<>();
 
+    //옵션 파일
+    private List<MultipartFile> optionFiles = new ArrayList<>();
+
     // 하위 타입 DTO
     private DonationProjectDetail donationDetail;
     private PurchaseProjectDetail purchaseDetail;

--- a/backend/src/main/java/com/funding/backend/domain/project/dto/response/PurchaseOptionResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/dto/response/PurchaseOptionResponseDto.java
@@ -2,6 +2,7 @@ package com.funding.backend.domain.project.dto.response;
 
 import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
 import com.funding.backend.enums.OptionStatus;
+import com.funding.backend.enums.ProvidingMethod;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,7 @@ public class PurchaseOptionResponseDto {
     private Long price;
     private String fileUrl;
     private OptionStatus optionStatus;
+    private ProvidingMethod providingMethod;
 
 
     public PurchaseOptionResponseDto(PurchaseOption purchaseOption){
@@ -23,5 +25,6 @@ public class PurchaseOptionResponseDto {
         this.price = purchaseOption.getPrice();
         this.fileUrl = purchaseOption.getFileUrl();
         this.optionStatus = purchaseOption.getOptionStatus();
+        this.providingMethod = purchaseOption.getProvidingMethod();
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/project/dto/response/PurchaseProjectResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/dto/response/PurchaseProjectResponseDto.java
@@ -18,7 +18,6 @@ public class PurchaseProjectResponseDto implements ProjectResponseDto {
     private String introduce;
     private String content;
     private String gitAddress;
-    private ProvidingMethod providingMethod;
     private Long purchaseCategoryId;
     private String purchaseCategoryName;
     private String averageDeliveryTime;
@@ -32,7 +31,6 @@ public class PurchaseProjectResponseDto implements ProjectResponseDto {
         this.introduce = project.getIntroduce();
         this.content = project.getContent();
         this.gitAddress = purchase.getGitAddress();
-        this.providingMethod = purchase.getProvidingMethod();
 
         if (purchase.getPurchaseCategory() != null) {
             this.purchaseCategoryId = purchase.getPurchaseCategory().getId();

--- a/backend/src/main/java/com/funding/backend/domain/project/dto/response/PurchaseProjectResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/dto/response/PurchaseProjectResponseDto.java
@@ -3,8 +3,7 @@ package com.funding.backend.domain.project.dto.response;
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.projectImage.entity.ProjectImage;
 import com.funding.backend.domain.purchase.entity.Purchase;
-import com.funding.backend.enums.OptionStatus;
-import com.funding.backend.enums.ProvidingMethod;
+import com.funding.backend.domain.purchaseOption.dto.response.PurchaseOptionResponseDto;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/backend/src/main/java/com/funding/backend/domain/project/entity/Project.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/entity/Project.java
@@ -61,9 +61,6 @@ public class Project extends Auditable {
     @Column(name = "status")
     private ProjectStatus projectStatus; // 프로젝트 상태
 
-    @Column(name = "cover_image")
-    private String coverImage;
-
     @Column(name = "title", nullable = false)
     private String title;
 

--- a/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
@@ -115,7 +115,6 @@ public class ProjectService {
 
 
 
-
     public Project findProjectById(Long id){
         return projectRepository.findById(id).orElseThrow(
                 () -> new BusinessLogicException(ExceptionCode.PROJECT_NOT_FOUND)

--- a/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
@@ -9,18 +9,24 @@ import com.funding.backend.domain.project.dto.response.PurchaseProjectResponseDt
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.project.repository.ProjectRepository;
 import com.funding.backend.domain.projectImage.entity.ProjectImage;
+import com.funding.backend.domain.purchase.dto.request.PurchaseOptionRequestDto;
+import com.funding.backend.domain.purchase.dto.request.PurchaseProjectDetail;
 import com.funding.backend.domain.purchase.dto.request.PurchaseUpdateRequestDto;
 import com.funding.backend.domain.purchase.entity.Purchase;
 import com.funding.backend.domain.purchase.service.PurchaseService;
 import com.funding.backend.domain.purchaseCategory.entity.PurchaseCategory;
 import com.funding.backend.domain.purchaseCategory.service.PurchaseCategoryService;
+import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
+import com.funding.backend.domain.purchaseOption.service.PurchaseOptionService;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.domain.user.repository.UserRepository;
 import com.funding.backend.enums.ProjectStatus;
 import com.funding.backend.enums.ProjectType;
+import com.funding.backend.enums.ProvidingMethod;
 import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.global.utils.s3.ImageService;
+import com.funding.backend.global.utils.s3.S3FileInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -44,27 +51,42 @@ public class ProjectService {
     private final ImageService imageService;
     private final PurchaseService purchaseService;
     private final UserRepository userRepository;
+    private final PurchaseOptionService purchaseOptionService;
 
 
     @Transactional
     public void createPurchaseProject(ProjectCreateRequestDto dto){
-        List<ProjectImage> projectImage = new ArrayList<>();
+
         Optional<User> user = userRepository.findById(Long.valueOf(1));
         Project project = Project.builder()
                 .introduce(dto.getIntroduce())
                 .title(dto.getTitle())
                 .content(dto.getContent())
-                .projectImage(projectImage)
                 .projectStatus(ProjectStatus.UNDER_REVIEW) //처음 만들때는 심사중으로
                 .pricingPlan(pricingService.findById(dto.getPricingPlanId()))
                 .projectType(ProjectType.PURCHASE)
                 .user(user.get())
                 .build();
+
+        //여기서도 이미지가 존재하는 경우만 저장되게
         Project saveProject = projectRepository.save(project);
 
-        imageService.saveImageList(dto.getContentImage(),saveProject);
-        purchaseService.createPurchase(saveProject,dto.getPurchaseDetail());
+        List<ProjectImage> projectImage = new ArrayList<>();
+        if (dto.getContentImage() != null && !dto.getContentImage().isEmpty()) {
+            projectImage = imageService.saveImageList(dto.getContentImage(), project);
+        }
+        project.setProjectImage(projectImage);
+
+
+        //구매 프로젝트 정보 저장
+        Purchase createPurchase = purchaseService.createPurchase(saveProject,dto.getPurchaseDetail());
+        // 옵션 저장
+        if (dto.getPurchaseDetail().getPurchaseOptionList() != null && !dto.getPurchaseDetail().getPurchaseOptionList().isEmpty()) {
+            purchaseOptionService.createPurchaseOptionForProject(createPurchase.getId(),dto);
+        }
+
     }
+
 
     @Transactional
     public void  updatePurchaseProject(Long projectId, PurchaseUpdateRequestDto purchaseUpdateRequestDto) {
@@ -90,9 +112,6 @@ public class ProjectService {
         // Purchase 관련 필드 업데이트
         purchaseService.updatePurchase(project,purchaseUpdateRequestDto);
     }
-
-
-
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
@@ -49,14 +49,12 @@ public class ProjectService {
     @Transactional
     public void createPurchaseProject(ProjectCreateRequestDto dto){
         List<ProjectImage> projectImage = new ArrayList<>();
-        String coverImage = "";
-        Optional<User> user = userRepository.findById(Long.valueOf(2));
+        Optional<User> user = userRepository.findById(Long.valueOf(1));
         Project project = Project.builder()
                 .introduce(dto.getIntroduce())
                 .title(dto.getTitle())
                 .content(dto.getContent())
                 .projectImage(projectImage)
-                .coverImage(coverImage)
                 .projectStatus(ProjectStatus.UNDER_REVIEW) //처음 만들때는 심사중으로
                 .pricingPlan(pricingService.findById(dto.getPricingPlanId()))
                 .projectType(ProjectType.PURCHASE)

--- a/backend/src/main/java/com/funding/backend/domain/purchase/controller/PurchaseController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/controller/PurchaseController.java
@@ -4,6 +4,7 @@ import com.funding.backend.domain.project.dto.request.ProjectCreateRequestDto;
 import com.funding.backend.domain.project.service.ProjectService;
 import com.funding.backend.domain.purchase.dto.request.PurchaseUpdateRequestDto;
 import com.funding.backend.domain.purchase.service.PurchaseService;
+import com.funding.backend.enums.ProvidingMethod;
 import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,16 +44,9 @@ public class PurchaseController {
             @RequestPart(value = "contentImage", required = false) List<MultipartFile> contentImages,
             @RequestPart(value = "optionFiles", required = false) List<MultipartFile> optionFiles
     ) {
-        // 프로젝트 이미지 저장
         requestDto.setContentImage(contentImages);
-
-
-        //프로젝트 구매 옵션 파일 저장 후 url 매핑
-        purchaseService.matchOptionFilesToDto(requestDto.getPurchaseDetail().getPurchaseOptionList(), optionFiles);
-
-
+        requestDto.setOptionFiles(optionFiles);
         projectService.createPurchaseProject(requestDto);
-
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.of(HttpStatus.CREATED.value(), "구매형 프로젝트 생성 성공"));
     }

--- a/backend/src/main/java/com/funding/backend/domain/purchase/controller/PurchaseController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/controller/PurchaseController.java
@@ -77,17 +77,6 @@ public class PurchaseController {
 
 
 
-    @GetMapping("/{projectId}")
-    @Operation(
-            summary = "구매형 프로젝트 상세 조회",
-            description = "구매형 프로젝트(Purchase)의 상세 정보를 조회합니다. 제목, 소개, Git 주소, 제공 방식, 가격제도, 파일 정보 등을 반환합니다."
-    )
-    public ResponseEntity<PurchaseProjectResponseDto> getPurchaseProject(
-            @PathVariable Long projectId
-    ) {
-        PurchaseProjectResponseDto response = projectService.getPurchaseProject(projectId);
-        return ResponseEntity.ok(response);
-    }
 
 
     //프로젝트에서 삭제하는거 있긴한데, 혹시 몰라서 만들어둠

--- a/backend/src/main/java/com/funding/backend/domain/purchase/controller/PurchaseController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/controller/PurchaseController.java
@@ -1,7 +1,6 @@
 package com.funding.backend.domain.purchase.controller;
 
 import com.funding.backend.domain.project.dto.request.ProjectCreateRequestDto;
-import com.funding.backend.domain.project.dto.response.PurchaseProjectResponseDto;
 import com.funding.backend.domain.project.service.ProjectService;
 import com.funding.backend.domain.purchase.dto.request.PurchaseUpdateRequestDto;
 import com.funding.backend.domain.purchase.service.PurchaseService;
@@ -17,12 +16,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;

--- a/backend/src/main/java/com/funding/backend/domain/purchase/dto/request/PurchaseOptionRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/dto/request/PurchaseOptionRequestDto.java
@@ -1,6 +1,8 @@
 package com.funding.backend.domain.purchase.dto.request;
 
 import com.funding.backend.enums.OptionStatus;
+import com.funding.backend.enums.ProvidingMethod;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,15 +10,21 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+//프로젝트 생성할때 쓰이는 optionRequestDto
 public class PurchaseOptionRequestDto {
     private String title;
     private String content;
     private Long price;
     private String fileUrl;
     private OptionStatus optionStatus;
-    private String original_file_name;
-    private String file_type;
-    private Long file_size;
+    private String fileIdentifier;
 
+    // 추가 정보 -> 매핑을 위한 필드
+    private String originalFileName;
+    private Long fileSize;
+    private String fileType;
+
+    @Pattern(regexp = "^(DOWNLOAD|EMAIL)$", message = "전송 방식은 DOWNLOAD 또는 EMAIL이어야 합니다.")
+    private ProvidingMethod providingMethod;// DOWNLOAD, EMAIL 등
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchase/dto/request/PurchaseOptionRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/dto/request/PurchaseOptionRequestDto.java
@@ -14,4 +14,9 @@ public class PurchaseOptionRequestDto {
     private Long price;
     private String fileUrl;
     private OptionStatus optionStatus;
+    private String original_file_name;
+    private String file_type;
+    private Long file_size;
+
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchase/dto/request/PurchaseProjectDetail.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/dto/request/PurchaseProjectDetail.java
@@ -15,8 +15,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class PurchaseProjectDetail {
-    @Pattern(regexp = "^(DOWNLOAD|EMAIL)$", message = "전송 방식은 DOWNLOAD 또는 EMAIL이어야 합니다.")
-    private ProvidingMethod providingMethod;// DOWNLOAD, EMAIL 등
 
     @NotBlank(message = "Git 주소는 필수입니다.")
     private String gitAddress;

--- a/backend/src/main/java/com/funding/backend/domain/purchase/dto/request/PurchaseUpdateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/dto/request/PurchaseUpdateRequestDto.java
@@ -22,7 +22,6 @@ public class PurchaseUpdateRequestDto {
     @NotNull(message = "프로젝트 타입은 필수입니다.")
     private ProjectType projectType;
 
-
     @NotBlank(message = "제목은 필수입니다.")
     @Size(max = 100, message = "제목은 100자 이내여야 합니다.")
     private String title;
@@ -37,10 +36,6 @@ public class PurchaseUpdateRequestDto {
 
     //이미지
     private List<MultipartFile> contentImage = new ArrayList<>();
-
-    @NotNull(message = "전송 방식은 DOWNLOAD 또는 EMAIL이어야 합니다.")
-    private ProvidingMethod providingMethod;
-
 
     @NotBlank(message = "Git 주소는 필수입니다.")
     private String gitAddress;

--- a/backend/src/main/java/com/funding/backend/domain/purchase/entity/Purchase.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/entity/Purchase.java
@@ -49,9 +49,6 @@ public class Purchase extends Auditable {
     @Column(name = "git_address", nullable = false)
     private String gitAddress;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "providing_method")
-    private ProvidingMethod providingMethod; // 다운로드, 이메일 중 하나
 
     @Column(name = "average_delivery_time")
     private String averageDeliveryTime;

--- a/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
@@ -1,37 +1,26 @@
 package com.funding.backend.domain.purchase.service;
 
-import com.funding.backend.domain.project.dto.response.PurchaseOptionResponseDto;
+import com.funding.backend.domain.purchaseOption.dto.response.PurchaseOptionResponseDto;
 import com.funding.backend.domain.project.dto.response.PurchaseProjectResponseDto;
 import com.funding.backend.domain.project.repository.ProjectRepository;
-import com.funding.backend.domain.project.service.ProjectService;
 import com.funding.backend.domain.purchase.dto.request.PurchaseProjectDetail;
 import com.funding.backend.domain.purchase.dto.request.PurchaseUpdateRequestDto;
 import com.funding.backend.domain.purchaseCategory.entity.PurchaseCategory;
 import com.funding.backend.domain.purchaseCategory.service.PurchaseCategoryService;
-import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
-import com.funding.backend.domain.purchase.dto.request.PurchaseOptionRequestDto;
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.purchase.entity.Purchase;
 import com.funding.backend.domain.purchase.repository.PurchaseRepository;
 import com.funding.backend.domain.purchaseOption.repository.PurchaseOptionRepository;
 import com.funding.backend.domain.purchaseOption.service.PurchaseOptionService;
-import com.funding.backend.domain.user.repository.UserRepository;
-import com.funding.backend.enums.ProvidingMethod;
 import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.global.utils.s3.ImageService;
-import com.funding.backend.global.utils.s3.S3FileInfo;
-import com.funding.backend.global.utils.s3.S3Uploader;
-import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
@@ -14,7 +14,9 @@ import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.purchase.entity.Purchase;
 import com.funding.backend.domain.purchase.repository.PurchaseRepository;
 import com.funding.backend.domain.purchaseOption.repository.PurchaseOptionRepository;
+import com.funding.backend.domain.purchaseOption.service.PurchaseOptionService;
 import com.funding.backend.domain.user.repository.UserRepository;
+import com.funding.backend.enums.ProvidingMethod;
 import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.global.utils.s3.ImageService;
@@ -22,7 +24,9 @@ import com.funding.backend.global.utils.s3.S3FileInfo;
 import com.funding.backend.global.utils.s3.S3Uploader;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -40,37 +44,19 @@ public class PurchaseService {
     private final ImageService imageService;
     private final ProjectRepository projectRepository;
     private final PurchaseCategoryService purchaseCategoryService;
+    private final PurchaseOptionService purchaseOptionService;
 
     @Transactional
-    public void createPurchase(Project project, PurchaseProjectDetail dto){
+    public Purchase createPurchase(Project project, PurchaseProjectDetail dto){
         PurchaseCategory purchaseCategory = purchaseCategoryService.findPurchaseCategoryById(dto.getPurchaseCategoryId());
 
         Purchase purchase = Purchase.builder()
                 .project(project)
                 .averageDeliveryTime(dto.getGetAverageDeliveryTime())
                 .gitAddress(dto.getGitAddress())
-                .providingMethod(dto.getProvidingMethod())
                 .purchaseCategory(purchaseCategory)
                 .build();
-        Purchase savePurchase = purchaseRepository.save(purchase);
-
-        // 옵션 저장
-        if (dto.getPurchaseOptionList() != null && !dto.getPurchaseOptionList().isEmpty()) {
-            for (PurchaseOptionRequestDto optionDto : dto.getPurchaseOptionList()) {
-                PurchaseOption option = PurchaseOption.builder()
-                        .purchase(savePurchase)
-                        .title(optionDto.getTitle())
-                        .content(optionDto.getContent())
-                        .fileUrl(optionDto.getFileUrl())
-                        .fileSize(optionDto.getFile_size())
-                        .fileType(optionDto.getFile_type())
-                        .originalFileName(optionDto.getOriginal_file_name())
-                        .price(optionDto.getPrice())
-                        .optionStatus(optionDto.getOptionStatus())
-                        .build();
-                purchaseOptionRepository.save(option);
-            }
-        }
+        return purchaseRepository.save(purchase);
     }
 
     @Transactional
@@ -85,8 +71,6 @@ public class PurchaseService {
         Optional.ofNullable(dto.getGitAddress())
                 .ifPresent(purchase::setGitAddress);
 
-        Optional.ofNullable(dto.getProvidingMethod())
-                .ifPresent(purchase::setProvidingMethod);
 
         Optional.ofNullable(dto.getAverageDeliveryTime())
                 .ifPresent(purchase::setAverageDeliveryTime);
@@ -111,31 +95,14 @@ public class PurchaseService {
         return purchaseRepository.findByProject(project)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PURCHASE_NOT_FOUND));
     }
-
-
-    //파일 이름을, dto에 저장 할 수 있게
-    public void matchOptionFilesToDto(
-            List<PurchaseOptionRequestDto> purchaseOptionRequestDto,
-            List<MultipartFile> files
-    ) {
-        if (purchaseOptionRequestDto == null || files == null) return;
-
-        if (purchaseOptionRequestDto.size() != files.size()) {
-            throw new BusinessLogicException(ExceptionCode.PURCHASE_OPTION_FILE_COUNT);
-        }
-
-        for (int i = 0; i < purchaseOptionRequestDto.size(); i++) {
-            MultipartFile file = files.get(i);
-            S3FileInfo fileInfo = imageService.saveFile(file);
-
-            PurchaseOptionRequestDto option = purchaseOptionRequestDto.get(i);
-            option.setFileUrl(fileInfo.fileUrl());
-            option.setFile_type(fileInfo.fileType());
-            option.setFile_size(fileInfo.fileSize());
-            option.setOriginal_file_name(fileInfo.originalFileName());
-
-        }
+    public Purchase findByProject(Long purchaseId ){
+        return purchaseRepository.findById(purchaseId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PURCHASE_NOT_FOUND));
     }
+
+
+
+
 
     public PurchaseProjectResponseDto createPurchaseProjectResponse(Project project) {
         Purchase detail = findByProject(project);
@@ -144,9 +111,11 @@ public class PurchaseService {
                 .map(PurchaseOptionResponseDto::new).toList();
 
         return new PurchaseProjectResponseDto(
-               project,detail,optionDtos
+                project, detail, optionDtos
         );
     }
+
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
@@ -67,7 +67,6 @@ public class PurchaseService {
             PurchaseCategory category = purchaseCategoryService.findPurchaseCategoryById(dto.getPurchaseCategoryId());
             purchase.setPurchaseCategory(category);
         }
-
         Optional.ofNullable(dto.getGitAddress())
                 .ifPresent(purchase::setGitAddress);
 

--- a/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
@@ -11,6 +11,7 @@ import com.funding.backend.domain.purchaseOption.repository.PurchaseOptionReposi
 import com.funding.backend.domain.user.repository.UserRepository;
 import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
+import com.funding.backend.global.utils.s3.ImageService;
 import com.funding.backend.global.utils.s3.S3FileInfo;
 import com.funding.backend.global.utils.s3.S3Uploader;
 import java.io.IOException;
@@ -30,7 +31,7 @@ public class PurchaseService {
 
     private final PurchaseRepository purchaseRepository;
     private final PurchaseOptionRepository purchaseOptionRepository;
-    private final S3Uploader s3Uploader;
+    private final ImageService imageService;
 
     @Transactional
     public void createPurchase(Project project, PurchaseProjectDetail dto){
@@ -106,15 +107,11 @@ public class PurchaseService {
 
         for (int i = 0; i < purchaseOptionRequestDto.size(); i++) {
             MultipartFile file = files.get(i);
-            try {
-                S3FileInfo fileInfo = s3Uploader.uploadAnyFile(file);
+            S3FileInfo fileInfo = imageService.saveFile(file);
 
-                PurchaseOptionRequestDto option = purchaseOptionRequestDto.get(i);
-                option.setFileUrl(fileInfo.fileUrl());
+            PurchaseOptionRequestDto option = purchaseOptionRequestDto.get(i);
+            option.setFileUrl(fileInfo.fileUrl());
 
-            } catch (IOException e) {
-                throw new RuntimeException("옵션 파일 업로드 실패: " + file.getOriginalFilename(), e);
-            }
         }
     }
 

--- a/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/service/PurchaseService.java
@@ -62,6 +62,9 @@ public class PurchaseService {
                         .title(optionDto.getTitle())
                         .content(optionDto.getContent())
                         .fileUrl(optionDto.getFileUrl())
+                        .fileSize(optionDto.getFile_size())
+                        .fileType(optionDto.getFile_type())
+                        .originalFileName(optionDto.getOriginal_file_name())
                         .price(optionDto.getPrice())
                         .optionStatus(optionDto.getOptionStatus())
                         .build();
@@ -127,6 +130,9 @@ public class PurchaseService {
 
             PurchaseOptionRequestDto option = purchaseOptionRequestDto.get(i);
             option.setFileUrl(fileInfo.fileUrl());
+            option.setFile_type(fileInfo.fileType());
+            option.setFile_size(fileInfo.fileSize());
+            option.setOriginal_file_name(fileInfo.originalFileName());
 
         }
     }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
@@ -1,13 +1,11 @@
 package com.funding.backend.domain.purchaseOption.controller;
 
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionCreateRequestDto;
-import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionRequestDto;
 import com.funding.backend.domain.purchaseOption.service.PurchaseOptionService;
 import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -41,7 +39,7 @@ public class PurchaseOptionController {
             @PathVariable Long projectId,
             @ModelAttribute @Valid PurchaseOptionCreateRequestDto requestDto
     ) {
-        purchaseOptionService.createPurchaseProject(requestDto);
+        purchaseOptionService.createPurchaseProject(projectId,requestDto);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.of(HttpStatus.CREATED.value(), "구매 옵션 생성 성공"));

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
@@ -7,12 +7,15 @@ import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.beans.PropertyEditorSupport;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/purchaseOption")
@@ -63,6 +67,20 @@ public class PurchaseOptionController {
                 .status(HttpStatus.OK)
                 .body(ApiResponse.of(HttpStatus.OK.value(), "구매 옵션 수정 성공"));
     }
+
+    // PurchaseOptionController 내부
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.registerCustomEditor(MultipartFile.class, new PropertyEditorSupport() {
+            @Override
+            public void setAsText(String text) {
+                setValue(null);
+            }
+        });
+    }
+
+
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
@@ -1,5 +1,6 @@
 package com.funding.backend.domain.purchaseOption.controller;
 
+import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionCreateRequestDto;
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionRequestDto;
 import com.funding.backend.domain.purchaseOption.service.PurchaseOptionService;
 import com.funding.backend.global.utils.ApiResponse;
@@ -10,9 +11,12 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,20 +32,20 @@ public class PurchaseOptionController {
 
     private final PurchaseOptionService purchaseOptionService;
 
-    @PutMapping("/{purchaseId}")
+    @PostMapping(value = "/{projectId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
-            summary = "구매형 옵션 수정",
-            description = "기존 구매형 프로젝트 옵션(PurchaseOption)을 전체 교체합니다. 기존 옵션은 모두 삭제되고, 전달된 새 옵션 리스트로 대체됩니다."
+            summary = "구매 옵션 생성",
+            description = "구매 옵션(PurchaseOption)을 생성합니다."
     )
-    public ResponseEntity<?> updatePurchaseOptions(
-            @PathVariable Long purchaseId,
-            @RequestBody @Valid List<PurchaseOptionRequestDto> purchaseOptionRequestDto
+    public ResponseEntity<ApiResponse<Void>> createPurchaseProject(
+            @PathVariable Long projectId,
+            @ModelAttribute @Valid PurchaseOptionCreateRequestDto requestDto
     ) {
-        purchaseOptionService.updateOptions(purchaseId, purchaseOptionRequestDto);
-        return new ResponseEntity<>(
-                ApiResponse.of(HttpStatus.OK.value(), "구매형 옵션 수정 성공"),
-                HttpStatus.OK
-        );
+        purchaseOptionService.createPurchaseProject(requestDto);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.of(HttpStatus.CREATED.value(), "구매 옵션 생성 성공"));
     }
+
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
@@ -40,7 +40,7 @@ public class PurchaseOptionController {
             @PathVariable Long projectId,
             @ModelAttribute @Valid PurchaseOptionCreateRequestDto requestDto
     ) {
-        purchaseOptionService.createPurchaseProject(projectId,requestDto);
+        purchaseOptionService.createPurchaseOption(projectId,requestDto);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.of(HttpStatus.CREATED.value(), "구매 옵션 생성 성공"));
@@ -51,6 +51,8 @@ public class PurchaseOptionController {
     @Operation(
             summary = "구매 옵션 수정",
             description = "구매 옵션(PurchaseOption)을 수정합니다. 파일, 가격, 상태, 설명 등을 변경할 수 있습니다."
+                    + " 파일은 선택적으로 업로드할 수 있습니다."
+
     )
     public ResponseEntity<ApiResponse<Void>> updatePurchaseOption(
             @PathVariable Long optionId,

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,11 +24,11 @@ import org.springframework.web.bind.annotation.RestController;
 @AllArgsConstructor
 @Tag(name = "구매 옵션 관리 컨트롤러")
 @Slf4j
-public class OptionController {
+public class PurchaseOptionController {
 
     private final PurchaseOptionService purchaseOptionService;
 
-    @PutMapping("/purchase/{purchaseId}/options")
+    @PutMapping("/{purchaseId}")
     @Operation(
             summary = "구매형 옵션 수정",
             description = "기존 구매형 프로젝트 옵션(PurchaseOption)을 전체 교체합니다. 기존 옵션은 모두 삭제되고, 전달된 새 옵션 리스트로 대체됩니다."

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
@@ -1,5 +1,6 @@
 package com.funding.backend.domain.purchaseOption.controller;
 
+import com.funding.backend.domain.project.dto.response.PurchaseOptionResponseDto;
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionCreateRequestDto;
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionUpdateRequestDto;
 import com.funding.backend.domain.purchaseOption.service.PurchaseOptionService;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.beans.PropertyEditorSupport;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -67,6 +70,21 @@ public class PurchaseOptionController {
                 .status(HttpStatus.OK)
                 .body(ApiResponse.of(HttpStatus.OK.value(), "구매 옵션 수정 성공"));
     }
+
+    @GetMapping("/{projectId}")
+    @Operation(
+            summary = "구매 옵션 리스트 조회",
+            description = "특정 프로젝트에 등록된 모든 구매 옵션(PurchaseOption)을 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<List<PurchaseOptionResponseDto>>> getPurchaseOptionsByProject(
+            @PathVariable Long projectId
+    ) {
+        List<PurchaseOptionResponseDto> options = purchaseOptionService.getPurchaseOptionsByProject(projectId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "구매 옵션 리스트 조회 성공", options));
+    }
+
 
     // PurchaseOptionController 내부
     @InitBinder

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
@@ -1,6 +1,7 @@
 package com.funding.backend.domain.purchaseOption.controller;
 
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionCreateRequestDto;
+import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionUpdateRequestDto;
 import com.funding.backend.domain.purchaseOption.service.PurchaseOptionService;
 import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,6 +45,23 @@ public class PurchaseOptionController {
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.of(HttpStatus.CREATED.value(), "구매 옵션 생성 성공"));
     }
+
+
+    @PutMapping(value = "/{optionId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "구매 옵션 수정",
+            description = "구매 옵션(PurchaseOption)을 수정합니다. 파일, 가격, 상태, 설명 등을 변경할 수 있습니다."
+    )
+    public ResponseEntity<ApiResponse<Void>> updatePurchaseOption(
+            @PathVariable Long optionId,
+            @ModelAttribute @Valid PurchaseOptionUpdateRequestDto requestDto
+    ) {
+        purchaseOptionService.updatePurchaseOption(optionId, requestDto);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "구매 옵션 수정 성공"));
+    }
+
 
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/controller/PurchaseOptionController.java
@@ -1,6 +1,6 @@
 package com.funding.backend.domain.purchaseOption.controller;
 
-import com.funding.backend.domain.project.dto.response.PurchaseOptionResponseDto;
+import com.funding.backend.domain.purchaseOption.dto.response.PurchaseOptionResponseDto;
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionCreateRequestDto;
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionUpdateRequestDto;
 import com.funding.backend.domain.purchaseOption.service.PurchaseOptionService;
@@ -17,13 +17,13 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -96,6 +96,22 @@ public class PurchaseOptionController {
             }
         });
     }
+
+    @DeleteMapping("/{optionId}")
+    @Operation(
+            summary = "구매 옵션 삭제",
+            description = "구매 옵션 ID(optionId)를 기반으로 해당 구매 옵션(PurchaseOption)을 삭제합니다."
+    )
+    public ResponseEntity<ApiResponse<Void>> deletePurchaseOption(
+            @PathVariable Long optionId
+    ) {
+        purchaseOptionService.deletePurchaseOption(optionId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "구매 옵션 삭제 성공"));
+
+    }
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionCreateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionCreateRequestDto.java
@@ -5,9 +5,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class PurchaseOptionCreateRequestDto {
     @NotBlank

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionCreateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionCreateRequestDto.java
@@ -5,15 +5,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
-@Setter
 @NoArgsConstructor
-public class PurchaseOptionRequestDto {
+public class PurchaseOptionCreateRequestDto {
     @NotBlank
     private String title;
-
     @NotBlank
     private String content;
 
@@ -22,4 +20,7 @@ public class PurchaseOptionRequestDto {
 
     @NotNull
     private OptionStatus optionStatus;
+
+    @NotNull
+    private MultipartFile file;
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionCreateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionCreateRequestDto.java
@@ -1,6 +1,7 @@
 package com.funding.backend.domain.purchaseOption.dto.request;
 
 import com.funding.backend.enums.OptionStatus;
+import com.funding.backend.enums.ProvidingMethod;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -20,11 +21,11 @@ public class PurchaseOptionCreateRequestDto {
     @NotNull
     private Long price;
 
-
+    @NotNull
+    private ProvidingMethod providingMethod;// DOWNLOAD, EMAIL 등
 
     @NotNull
     private OptionStatus optionStatus;
 
-    @NotNull
     private MultipartFile file;
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionCreateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionCreateRequestDto.java
@@ -20,6 +20,8 @@ public class PurchaseOptionCreateRequestDto {
     @NotNull
     private Long price;
 
+
+
     @NotNull
     private OptionStatus optionStatus;
 

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionUpdateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionUpdateRequestDto.java
@@ -1,13 +1,16 @@
 package com.funding.backend.domain.purchaseOption.dto.request;
 
 import com.funding.backend.enums.OptionStatus;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class PurchaseOptionUpdateRequestDto {
 
@@ -23,5 +26,6 @@ public class PurchaseOptionUpdateRequestDto {
     @NotNull
     private OptionStatus optionStatus;
 
+    @Nullable
     private MultipartFile file; // 선택적 수정일 경우 @NotNull 제거
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionUpdateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package com.funding.backend.domain.purchaseOption.dto.request;
 
 import com.funding.backend.enums.OptionStatus;
+import com.funding.backend.enums.ProvidingMethod;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -22,6 +23,10 @@ public class PurchaseOptionUpdateRequestDto {
 
     @NotNull
     private Long price;
+
+    @NotNull
+    private ProvidingMethod providingMethod;// DOWNLOAD, EMAIL 등
+
 
     @NotNull
     private OptionStatus optionStatus;

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionUpdateRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/request/PurchaseOptionUpdateRequestDto.java
@@ -1,0 +1,27 @@
+package com.funding.backend.domain.purchaseOption.dto.request;
+
+import com.funding.backend.enums.OptionStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@NoArgsConstructor
+public class PurchaseOptionUpdateRequestDto {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String content;
+
+    @NotNull
+    private Long price;
+
+    @NotNull
+    private OptionStatus optionStatus;
+
+    private MultipartFile file; // 선택적 수정일 경우 @NotNull 제거
+}

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/response/OptionResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/response/OptionResponseDto.java
@@ -1,4 +1,0 @@
-package com.funding.backend.domain.purchaseOption.dto.response;
-
-public class OptionResponseDto {
-}

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/response/PurchaseOptionResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/dto/response/PurchaseOptionResponseDto.java
@@ -1,4 +1,4 @@
-package com.funding.backend.domain.project.dto.response;
+package com.funding.backend.domain.purchaseOption.dto.response;
 
 import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
 import com.funding.backend.enums.OptionStatus;
@@ -17,6 +17,7 @@ public class PurchaseOptionResponseDto {
     private String fileUrl;
     private OptionStatus optionStatus;
     private ProvidingMethod providingMethod;
+    private Long purchaseOptionId;
 
 
     public PurchaseOptionResponseDto(PurchaseOption purchaseOption){
@@ -26,5 +27,6 @@ public class PurchaseOptionResponseDto {
         this.fileUrl = purchaseOption.getFileUrl();
         this.optionStatus = purchaseOption.getOptionStatus();
         this.providingMethod = purchaseOption.getProvidingMethod();
+        this.purchaseOptionId=purchaseOption.getId();
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/entity/PurchaseOption.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/entity/PurchaseOption.java
@@ -2,6 +2,7 @@ package com.funding.backend.domain.purchaseOption.entity;
 
 import com.funding.backend.domain.purchase.entity.Purchase;
 import com.funding.backend.enums.OptionStatus;
+import com.funding.backend.enums.ProvidingMethod;
 import com.funding.backend.global.auditable.Auditable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,6 +45,10 @@ public class PurchaseOption extends Auditable {
     @Enumerated(EnumType.STRING)
     @Column(name = "option_status", nullable = false)
     private OptionStatus optionStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "providing_method")
+    private ProvidingMethod providingMethod; // 다운로드, 이메일 중 하나
 
     @Column(name = "content", length = 100, nullable = false)
     private String content;

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/repository/PurchaseOptionRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/repository/PurchaseOptionRepository.java
@@ -2,10 +2,13 @@ package com.funding.backend.domain.purchaseOption.repository;
 
 import com.funding.backend.domain.purchase.entity.Purchase;
 import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PurchaseOptionRepository extends JpaRepository<PurchaseOption,Long> {
     void deleteByPurchase(Purchase purchase);
+    List<PurchaseOption> findAllByPurchase(Purchase purchase);
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
@@ -37,6 +37,7 @@ public class PurchaseOptionService {
         PurchaseOption purchaseOption = PurchaseOption.builder()
                 .optionStatus(requestDto.getOptionStatus())
                 .price(requestDto.getPrice())
+                .title(requestDto.getTitle())
                 .content(requestDto.getContent())
                 .fileSize(fileData.fileSize())
                 .originalFileName(fileData.originalFileName())

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
@@ -6,10 +6,16 @@ import com.funding.backend.domain.purchase.entity.Purchase;
 import com.funding.backend.domain.purchase.repository.PurchaseRepository;
 import com.funding.backend.domain.purchase.service.PurchaseService;
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionCreateRequestDto;
+import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionUpdateRequestDto;
 import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
 import com.funding.backend.domain.purchaseOption.repository.PurchaseOptionRepository;
+import com.funding.backend.enums.OptionStatus;
+import com.funding.backend.enums.ProvidingMethod;
+import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.global.utils.s3.ImageService;
 import com.funding.backend.global.utils.s3.S3FileInfo;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,11 +36,51 @@ public class PurchaseOptionService {
 
 
     @Transactional
-    public void createPurchaseProject(Long projectId, PurchaseOptionCreateRequestDto requestDto){
+    public void createPurchaseOption(Long projectId, PurchaseOptionCreateRequestDto requestDto) {
         Purchase purchase = purchaseService.findByProject(projectService.findProjectById(projectId));
-        S3FileInfo fileData = imageService.saveFile(requestDto.getFile());
 
-        PurchaseOption purchaseOption = PurchaseOption.builder()
+        if (purchase.getProvidingMethod().equals(ProvidingMethod.DOWNLOAD)) {
+            createDownloadOption(purchase, requestDto);
+        } else if (purchase.getProvidingMethod().equals(ProvidingMethod.EMAIL)) {
+            createEmailOption(purchase, requestDto);
+        } else {
+            throw new BusinessLogicException(ExceptionCode.UNSUPPORTED_PROVIDING_METHOD);
+        }
+    }
+
+    @Transactional
+    public void updatePurchaseOption(Long purchaseOptionId, PurchaseOptionUpdateRequestDto requestDto) {
+        PurchaseOption purchaseOption = findPurchaseOptionById(purchaseOptionId);
+
+        if (requestDto.getFile() != null) {
+            updateFileIfChanged(purchaseOption, requestDto.getFile());
+        }
+
+        Optional.ofNullable(requestDto.getTitle())
+                .ifPresent(purchaseOption::setTitle);
+        Optional.ofNullable(requestDto.getContent())
+                .ifPresent(purchaseOption::setContent);
+        Optional.ofNullable(requestDto.getOptionStatus())
+                .ifPresent(purchaseOption::setOptionStatus);
+        Optional.ofNullable(requestDto.getPrice())
+                .ifPresent(purchaseOption::setPrice);
+
+        purchaseOptionRepository.save(purchaseOption);
+    }
+
+
+    public PurchaseOption findPurchaseOptionById(Long purchaseOptionId){
+        return purchaseOptionRepository.findById(purchaseOptionId)
+                .orElseThrow(()-> new BusinessLogicException(ExceptionCode.PURCHASE_OPTION_NOT_FOUND));
+    }
+    private void createDownloadOption(Purchase purchase, PurchaseOptionCreateRequestDto requestDto) {
+        S3FileInfo fileData = imageService.saveFile(requestDto.getFile());
+        // 파일이 없으면 예외 던지기
+        if (requestDto.getFile() == null || requestDto.getFile().isEmpty()) {
+            throw new BusinessLogicException(ExceptionCode.FILE_REQUIRED_FOR_DOWNLOAD_OPTION);
+
+        }
+        PurchaseOption option = PurchaseOption.builder()
                 .optionStatus(requestDto.getOptionStatus())
                 .price(requestDto.getPrice())
                 .title(requestDto.getTitle())
@@ -45,12 +91,52 @@ public class PurchaseOptionService {
                 .fileUrl(fileData.fileUrl())
                 .purchase(purchase)
                 .build();
-        purchaseOptionRepository.save(purchaseOption);
+        purchaseOptionRepository.save(option);
+    }
+
+    private void createEmailOption(Purchase purchase, PurchaseOptionCreateRequestDto requestDto) {
+        PurchaseOption option = PurchaseOption.builder()
+                .optionStatus(requestDto.getOptionStatus())
+                .price(requestDto.getPrice())
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .purchase(purchase)
+                .build();
+        purchaseOptionRepository.save(option);
     }
 
 
+    private void updateFileIfChanged(PurchaseOption purchaseOption, MultipartFile newFile) {
+        String currentFileHash = generateFileHash(
+                purchaseOption.getOriginalFileName(),
+                purchaseOption.getFileSize(),
+                purchaseOption.getFileType()
+        );
+        String newFileHash = generateFileHash(newFile);
+
+        if (!currentFileHash.equals(newFileHash)) {
+            imageService.deleteImage(purchaseOption.getFileUrl());
+            S3FileInfo fileInfo = imageService.saveFile(newFile);
+
+            purchaseOption.setFileSize(fileInfo.fileSize());
+            purchaseOption.setFileType(fileInfo.fileType());
+            purchaseOption.setFileUrl(fileInfo.fileUrl());
+            purchaseOption.setOriginalFileName(fileInfo.originalFileName());
+        }
+    }
 
 
+    private String generateFileHash(String originalFileName, long fileSize, String fileType) {
+        return imageService.generateFileHash(originalFileName, fileSize, fileType);
+    }
+
+    private String generateFileHash(MultipartFile file) {
+        return imageService.generateFileHash(
+                file.getOriginalFilename(),
+                file.getSize(),
+                file.getContentType()
+        );
+    }
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
@@ -1,17 +1,19 @@
 package com.funding.backend.domain.purchaseOption.service;
 
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.project.service.ProjectService;
 import com.funding.backend.domain.purchase.entity.Purchase;
 import com.funding.backend.domain.purchase.repository.PurchaseRepository;
-import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionRequestDto;
+import com.funding.backend.domain.purchase.service.PurchaseService;
+import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionCreateRequestDto;
 import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
 import com.funding.backend.domain.purchaseOption.repository.PurchaseOptionRepository;
-import com.funding.backend.global.exception.BusinessLogicException;
-import com.funding.backend.global.exception.ExceptionCode;
-import java.util.List;
+import com.funding.backend.global.utils.s3.ImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -20,26 +22,35 @@ import org.springframework.transaction.annotation.Transactional;
 public class PurchaseOptionService {
     private final PurchaseOptionRepository purchaseOptionRepository;
     private final PurchaseRepository purchaseRepository;
+    private final ProjectService projectService;
+    private final PurchaseService purchaseService;
+    private final ImageService imageService;
+
+
 
     @Transactional
-    public void updateOptions(Long purchaseId, List<PurchaseOptionRequestDto> newOptions) {
-        Purchase purchase = purchaseRepository.findById(purchaseId)
-                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PURCHASE_NOT_FOUND));
+    public void createPurchaseProject(Long projectId, PurchaseOptionCreateRequestDto requestDto){
+        Purchase purchase = purchaseService.findByProject(projectService.findProjectById(projectId));
+        MultipartFile optionFile = requestDto.getFile();
+        String fileUrl = imageService.
 
-        // 기존 옵션 삭제
-        purchaseOptionRepository.deleteByPurchase(purchase);
+        PurchaseOption purchaseOption = PurchaseOption.builder()
+                .optionStatus(requestDto.getOptionStatus())
+                .price(requestDto.getPrice())
+                .content(requestDto.getContent())
+                .fileSize(optionFile.getSize())
+                .originalFileName(optionFile.getOriginalFilename())
+                .fileType(optionFile.getContentType())
+                .build();
 
-        // 새로운 옵션 저장
-        for (PurchaseOptionRequestDto dto : newOptions) {
-            PurchaseOption option = PurchaseOption.builder()
-                    .purchase(purchase)
-                    .title(dto.getTitle())
-                    .content(dto.getContent())
-                    .price(dto.getPrice())
-                    .optionStatus(dto.getOptionStatus())
-                    .build();
-            purchaseOptionRepository.save(option);
-        }
+
     }
+
+
+
+
+
+
+
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
@@ -84,10 +84,12 @@ public class PurchaseOptionService {
     public void updatePurchaseOption(Long purchaseOptionId, PurchaseOptionUpdateRequestDto requestDto) {
         PurchaseOption purchaseOption = findPurchaseOptionById(purchaseOptionId);
 
-        if (requestDto.getFile() != null) {
-            updateFileIfChanged(purchaseOption, requestDto.getFile());
+        ProvidingMethod method = requestDto.getProvidingMethod();
+        if (requestDto.getProvidingMethod() == null) {
+            throw new BusinessLogicException(ExceptionCode.UNSUPPORTED_PROVIDING_METHOD);
         }
 
+        // 공통 필드 업데이트
         Optional.ofNullable(requestDto.getTitle())
                 .ifPresent(purchaseOption::setTitle);
         Optional.ofNullable(requestDto.getContent())
@@ -97,8 +99,14 @@ public class PurchaseOptionService {
         Optional.ofNullable(requestDto.getPrice())
                 .ifPresent(purchaseOption::setPrice);
 
+        // DOWNLOAD일 때만 파일 처리
+        if (method.equals(ProvidingMethod.DOWNLOAD) && requestDto.getFile() != null) {
+            updateFileIfChanged(purchaseOption, requestDto.getFile());
+        }
+
         purchaseOptionRepository.save(purchaseOption);
     }
+
 
 
     public PurchaseOption findPurchaseOptionById(Long purchaseOptionId){
@@ -174,6 +182,8 @@ public class PurchaseOptionService {
                 .build();
         purchaseOptionRepository.save(option);
     }
+
+
 
     private void createEmailOptionWithProject(Purchase purchase, PurchaseOptionRequestDto requestDto) {
         PurchaseOption option = PurchaseOption.builder()

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
@@ -121,6 +121,7 @@ public class PurchaseOptionService {
                 .originalFileName(fileData.originalFileName())
                 .fileType(fileData.fileType())
                 .fileUrl(fileData.fileUrl())
+                .providingMethod(requestDto.getProvidingMethod())
                 .purchase(purchase)
                 .build();
         purchaseOptionRepository.save(option);
@@ -132,6 +133,7 @@ public class PurchaseOptionService {
                 .price(requestDto.getPrice())
                 .title(requestDto.getTitle())
                 .content(requestDto.getContent())
+                .providingMethod(requestDto.getProvidingMethod())
                 .purchase(purchase)
                 .build();
         purchaseOptionRepository.save(option);
@@ -167,6 +169,7 @@ public class PurchaseOptionService {
                 .originalFileName(requestDto.getOriginalFileName())
                 .fileType(requestDto.getFileType())
                 .fileUrl(requestDto.getFileUrl())
+                .providingMethod(requestDto.getProvidingMethod())
                 .purchase(purchase)
                 .build();
         purchaseOptionRepository.save(option);
@@ -178,6 +181,7 @@ public class PurchaseOptionService {
                 .price(requestDto.getPrice())
                 .title(requestDto.getTitle())
                 .content(requestDto.getContent())
+                .providingMethod(requestDto.getProvidingMethod())
                 .purchase(purchase)
                 .build();
         purchaseOptionRepository.save(option);

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
@@ -1,7 +1,10 @@
 package com.funding.backend.domain.purchaseOption.service;
 
+import com.funding.backend.domain.project.dto.request.ProjectCreateRequestDto;
 import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.project.repository.ProjectRepository;
 import com.funding.backend.domain.project.service.ProjectService;
+import com.funding.backend.domain.purchase.dto.request.PurchaseOptionRequestDto;
 import com.funding.backend.domain.purchase.entity.Purchase;
 import com.funding.backend.domain.purchase.repository.PurchaseRepository;
 import com.funding.backend.domain.purchase.service.PurchaseService;
@@ -15,7 +18,11 @@ import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.global.utils.s3.ImageService;
 import com.funding.backend.global.utils.s3.S3FileInfo;
+import java.text.Normalizer;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,19 +36,44 @@ import org.springframework.web.multipart.MultipartFile;
 public class PurchaseOptionService {
     private final PurchaseOptionRepository purchaseOptionRepository;
     private final PurchaseRepository purchaseRepository;
-    private final ProjectService projectService;
-    private final PurchaseService purchaseService;
+    private final ProjectRepository projectRepository;
     private final ImageService imageService;
 
+
+    @Transactional
+    public void createPurchaseOptionForProject(Long purchaseId, ProjectCreateRequestDto optionRequestDto) {
+        Purchase purchase = purchaseRepository.findById(purchaseId)
+                .orElseThrow(()->new BusinessLogicException(ExceptionCode.PURCHASE_NOT_FOUND));
+        List<PurchaseOptionRequestDto> purchaseOptionList = optionRequestDto.getPurchaseDetail().getPurchaseOptionList();
+        List<MultipartFile> optionFiles = optionRequestDto.getOptionFiles();
+
+        // 먼저 DTO와 파일 매핑
+        matchOptionFilesToDto(purchaseOptionList, optionFiles);
+
+        // 매핑된 DTO로 옵션 생성
+        for (PurchaseOptionRequestDto dto : purchaseOptionList) {
+            if (dto.getProvidingMethod() == ProvidingMethod.DOWNLOAD) {
+                createDownloadOptionWithProject(purchase, dto);
+            } else if (dto.getProvidingMethod() == ProvidingMethod.EMAIL) {
+                createEmailOptionWithProject(purchase, dto);
+            } else {
+                throw new BusinessLogicException(ExceptionCode.UNSUPPORTED_PROVIDING_METHOD);
+            }
+        }
+    }
 
 
     @Transactional
     public void createPurchaseOption(Long projectId, PurchaseOptionCreateRequestDto requestDto) {
-        Purchase purchase = purchaseService.findByProject(projectService.findProjectById(projectId));
 
-        if (purchase.getProvidingMethod().equals(ProvidingMethod.DOWNLOAD)) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(()->new BusinessLogicException(ExceptionCode.PROJECT_NOT_FOUND));
+        Purchase purchase = purchaseRepository.findByProject(project)
+                .orElseThrow(()->new BusinessLogicException(ExceptionCode.PURCHASE_NOT_FOUND));
+
+        if (requestDto.getProvidingMethod().equals(ProvidingMethod.DOWNLOAD)) {
             createDownloadOption(purchase, requestDto);
-        } else if (purchase.getProvidingMethod().equals(ProvidingMethod.EMAIL)) {
+        } else if (requestDto.getProvidingMethod().equals(ProvidingMethod.EMAIL)) {
             createEmailOption(purchase, requestDto);
         } else {
             throw new BusinessLogicException(ExceptionCode.UNSUPPORTED_PROVIDING_METHOD);
@@ -73,12 +105,12 @@ public class PurchaseOptionService {
         return purchaseOptionRepository.findById(purchaseOptionId)
                 .orElseThrow(()-> new BusinessLogicException(ExceptionCode.PURCHASE_OPTION_NOT_FOUND));
     }
+
     private void createDownloadOption(Purchase purchase, PurchaseOptionCreateRequestDto requestDto) {
         S3FileInfo fileData = imageService.saveFile(requestDto.getFile());
-        // 파일이 없으면 예외 던지기
+        // ✅ 파일이 없으면 예외 던지기
         if (requestDto.getFile() == null || requestDto.getFile().isEmpty()) {
             throw new BusinessLogicException(ExceptionCode.FILE_REQUIRED_FOR_DOWNLOAD_OPTION);
-
         }
         PurchaseOption option = PurchaseOption.builder()
                 .optionStatus(requestDto.getOptionStatus())
@@ -125,6 +157,33 @@ public class PurchaseOptionService {
         }
     }
 
+    private void createDownloadOptionWithProject(Purchase purchase, PurchaseOptionRequestDto requestDto) {
+        PurchaseOption option = PurchaseOption.builder()
+                .optionStatus(requestDto.getOptionStatus())
+                .price(requestDto.getPrice())
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .fileSize(requestDto.getFileSize())
+                .originalFileName(requestDto.getOriginalFileName())
+                .fileType(requestDto.getFileType())
+                .fileUrl(requestDto.getFileUrl())
+                .purchase(purchase)
+                .build();
+        purchaseOptionRepository.save(option);
+    }
+
+    private void createEmailOptionWithProject(Purchase purchase, PurchaseOptionRequestDto requestDto) {
+        PurchaseOption option = PurchaseOption.builder()
+                .optionStatus(requestDto.getOptionStatus())
+                .price(requestDto.getPrice())
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .purchase(purchase)
+                .build();
+        purchaseOptionRepository.save(option);
+    }
+
+
 
     private String generateFileHash(String originalFileName, long fileSize, String fileType) {
         return imageService.generateFileHash(originalFileName, fileSize, fileType);
@@ -136,6 +195,54 @@ public class PurchaseOptionService {
                 file.getSize(),
                 file.getContentType()
         );
+    }
+
+    //파일 이름을, dto에 저장 할 수 있게
+    public void matchOptionFilesToDto(
+            List<PurchaseOptionRequestDto> purchaseOptionRequestDto,
+            List<MultipartFile> files
+    ) {
+        if (purchaseOptionRequestDto == null || files == null) return;
+
+        // "DOWNLOAD" 상태인 옵션만 필터링
+        long downloadOptionCount = purchaseOptionRequestDto.stream()
+                .filter(option -> ProvidingMethod.DOWNLOAD.equals(option.getProvidingMethod()))
+                .count();
+
+        // 파일 개수와 DOWNLOAD 옵션 개수 비교
+        if (downloadOptionCount != files.size()) {
+            throw new BusinessLogicException(ExceptionCode.PURCHASE_OPTION_FILE_COUNT);
+        }
+
+        // 업로드된 파일을 이름으로 매핑
+        Map<String, MultipartFile> fileMap = files.stream()
+                .filter(file -> file.getOriginalFilename() != null)
+                .collect(Collectors.toMap(
+                        file -> Normalizer.normalize(file.getOriginalFilename(), Normalizer.Form.NFC),
+                        f -> f
+                ));
+
+
+        for (PurchaseOptionRequestDto option : purchaseOptionRequestDto) {
+            if (!ProvidingMethod.DOWNLOAD.equals(option.getProvidingMethod())) {
+                continue;
+            }
+            String identifier = option.getFileIdentifier();
+
+            if (identifier == null || !fileMap.containsKey(Normalizer.normalize(identifier, Normalizer.Form.NFC))) {
+                log.warn("❗ 파일 식별자 미일치: identifier = [{}], 파일 목록 = {}",
+                        identifier, fileMap.keySet());
+                throw new BusinessLogicException(ExceptionCode.PURCHASE_OPTION_FILE_NOT_FOUND);
+            }
+
+
+            MultipartFile matchedFile = fileMap.get(identifier);
+            S3FileInfo fileInfo = imageService.saveFile(matchedFile);
+            option.setFileUrl(fileInfo.fileUrl());
+            option.setFileSize(fileInfo.fileSize());
+            option.setFileType(fileInfo.fileType());
+            option.setOriginalFileName(fileInfo.originalFileName());
+        }
     }
 
 

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
@@ -9,6 +9,7 @@ import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionCreat
 import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
 import com.funding.backend.domain.purchaseOption.repository.PurchaseOptionRepository;
 import com.funding.backend.global.utils.s3.ImageService;
+import com.funding.backend.global.utils.s3.S3FileInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,19 +32,19 @@ public class PurchaseOptionService {
     @Transactional
     public void createPurchaseProject(Long projectId, PurchaseOptionCreateRequestDto requestDto){
         Purchase purchase = purchaseService.findByProject(projectService.findProjectById(projectId));
-        MultipartFile optionFile = requestDto.getFile();
-        String fileUrl = imageService.
+        S3FileInfo fileData = imageService.saveFile(requestDto.getFile());
 
         PurchaseOption purchaseOption = PurchaseOption.builder()
                 .optionStatus(requestDto.getOptionStatus())
                 .price(requestDto.getPrice())
                 .content(requestDto.getContent())
-                .fileSize(optionFile.getSize())
-                .originalFileName(optionFile.getOriginalFilename())
-                .fileType(optionFile.getContentType())
+                .fileSize(fileData.fileSize())
+                .originalFileName(fileData.originalFileName())
+                .fileType(fileData.fileType())
+                .fileUrl(fileData.fileUrl())
+                .purchase(purchase)
                 .build();
-
-
+        purchaseOptionRepository.save(purchaseOption);
     }
 
 

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/service/PurchaseOptionService.java
@@ -1,19 +1,16 @@
 package com.funding.backend.domain.purchaseOption.service;
 
 import com.funding.backend.domain.project.dto.request.ProjectCreateRequestDto;
-import com.funding.backend.domain.project.dto.response.PurchaseOptionResponseDto;
+import com.funding.backend.domain.purchaseOption.dto.response.PurchaseOptionResponseDto;
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.project.repository.ProjectRepository;
-import com.funding.backend.domain.project.service.ProjectService;
 import com.funding.backend.domain.purchase.dto.request.PurchaseOptionRequestDto;
 import com.funding.backend.domain.purchase.entity.Purchase;
 import com.funding.backend.domain.purchase.repository.PurchaseRepository;
-import com.funding.backend.domain.purchase.service.PurchaseService;
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionCreateRequestDto;
 import com.funding.backend.domain.purchaseOption.dto.request.PurchaseOptionUpdateRequestDto;
 import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
 import com.funding.backend.domain.purchaseOption.repository.PurchaseOptionRepository;
-import com.funding.backend.enums.OptionStatus;
 import com.funding.backend.enums.ProvidingMethod;
 import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
@@ -80,6 +77,8 @@ public class PurchaseOptionService {
 
     @Transactional
     public void updatePurchaseOption(Long purchaseOptionId, PurchaseOptionUpdateRequestDto requestDto) {
+        //수정하려는 사람이 해당 프로젝트를 생성한 사람인지 확인하는 로직 필요
+
         PurchaseOption purchaseOption = findPurchaseOptionById(purchaseOptionId);
 
         ProvidingMethod method = requestDto.getProvidingMethod();
@@ -273,6 +272,12 @@ public class PurchaseOptionService {
 
         return purchaseRepository.findByProject(project)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PURCHASE_NOT_FOUND));
+    }
+
+    @Transactional
+    public void deletePurchaseOption(Long optionId){
+        PurchaseOption purchaseOption = findPurchaseOptionById(optionId);
+        purchaseOptionRepository.delete(purchaseOption);
     }
 
 

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -14,6 +14,8 @@ public enum ExceptionCode {
 
     //구매 예외처리
     PURCHASE_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 입니다. "),
+    INVALID_PROVIDING_METHOD(400, "제공 방식이 유효하지 않습니다."),
+
 
     //구매 카테고리 예외처리
     PURCHASE_CATEGORY_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 카테고리 입니다. "),
@@ -24,12 +26,15 @@ public enum ExceptionCode {
     PURCHASE_OPTION_FILE_COUNT(404,"옵션 개수와 파일 개수가 일치하지 않습니다."),
     UNSUPPORTED_PROVIDING_METHOD(400, "지원하지 않는 제공 방식입니다."),
     FILE_REQUIRED_FOR_DOWNLOAD_OPTION(400, "DOWNLOAD 방식의 구매 옵션에는 파일이 필수입니다."),
+    PURCHASE_OPTION_FILE_NOT_FOUND(400, "해당 옵션에 매칭되는 파일을 찾을 수 없습니다."),
+
 
 
 
     //S3 예외 처리
     S3_DELETE_ERROR(404, "이미지를 삭제할 수 없습니다."),
     IMAGE_NOT_FOUND(404,"이미지를 찾을 수 없습니다."),
+    IMAGE_UPLOAD_FAILED(500, "이미지 업로드에 실패하였습니다."),
     FILE_UPLOAD_FAILED(500, "파일 업로드에 실패하였습니다."),
     INVALID_S3_URL_FORMAT(400, "잘못된 S3 URL 형식입니다."),
     ETAG_HASH_FAILED(500, "ETag 해시 계산에 실패하였습니다."),

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -19,6 +19,8 @@ public enum ExceptionCode {
     //S3 예외 처리
     S3_DELETE_ERROR(404, "이미지를 삭제할 수 없습니다."),
     IMAGE_NOT_FOUND(404,"이미지를 찾을 수 없습니다."),
+    FILE_UPLOAD_FAILED(500, "파일 업로드에 실패하였습니다."),
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -20,12 +20,20 @@ public enum ExceptionCode {
 
 
     //구매 옵션 예외처리
+    PURCHASE_OPTION_NOT_FOUND(404,"존재하지 않는 구매옵션 입니다."),
     PURCHASE_OPTION_FILE_COUNT(404,"옵션 개수와 파일 개수가 일치하지 않습니다."),
+    UNSUPPORTED_PROVIDING_METHOD(400, "지원하지 않는 제공 방식입니다."),
+    FILE_REQUIRED_FOR_DOWNLOAD_OPTION(400, "DOWNLOAD 방식의 구매 옵션에는 파일이 필수입니다."),
+
+
+
     //S3 예외 처리
     S3_DELETE_ERROR(404, "이미지를 삭제할 수 없습니다."),
     IMAGE_NOT_FOUND(404,"이미지를 찾을 수 없습니다."),
     FILE_UPLOAD_FAILED(500, "파일 업로드에 실패하였습니다."),
-
+    INVALID_S3_URL_FORMAT(400, "잘못된 S3 URL 형식입니다."),
+    ETAG_HASH_FAILED(500, "ETag 해시 계산에 실패하였습니다."),
+    MD5_HASH_FAILED(500, "MD5 해시 생성에 실패하였습니다."),
 
 
 

--- a/backend/src/main/java/com/funding/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/GlobalExceptionHandler.java
@@ -1,23 +1,23 @@
-//package com.funding.backend.global.exception;
-//
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.ExceptionHandler;
-//import org.springframework.web.bind.annotation.RestControllerAdvice;
-//
-//@Slf4j
-//@RestControllerAdvice
-//public class GlobalExceptionHandler {
-//
-//    @ExceptionHandler(BusinessLogicException.class)
-//    public ResponseEntity<ErrorResponse> handleBusinessLogicException(BusinessLogicException ex) {
-//        ExceptionCode code = ex.getExceptionCode();
-//
-//        // ✅ 서버 로그에 예외 전체 출력
-//        log.error("[BusinessLogicException] {} - {}", code.name(), code.getMessage(), ex);
-//
-//        return ResponseEntity
-//                .status(code.getStatus())
-//                .body(new ErrorResponse(code.getStatus(), code.getMessage()));
-//    }
-//}
+package com.funding.backend.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessLogicException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessLogicException(BusinessLogicException ex) {
+        ExceptionCode code = ex.getExceptionCode();
+
+        // ✅ 서버 로그에 예외 전체 출력
+        log.error("[BusinessLogicException] {} - {}", code.name(), code.getMessage(), ex);
+
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(new ErrorResponse(code.getStatus(), code.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/funding/backend/global/utils/ApiResponse.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.funding.backend.global.utils;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
     
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
@@ -66,7 +66,7 @@ public class ImageService {
 
                 savedList.add(projectImageRepository.save(pi));
             } catch (IOException e) {
-                throw new RuntimeException("이미지 업로드 실패", e);
+                throw new BusinessLogicException(ExceptionCode.IMAGE_UPLOAD_FAILED);
             }
         }
         return savedList;

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
@@ -5,6 +5,8 @@ package com.funding.backend.global.utils.s3;
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.projectImage.entity.ProjectImage;
 import com.funding.backend.domain.projectImage.repository.ProjectImageRepository;
+import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.exception.ExceptionCode;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -88,8 +90,13 @@ public class ImageService {
         return updated;
     }
 
-
-
+    public S3FileInfo saveFile(MultipartFile multipartFile) {
+        try {
+            return s3Uploader.uploadAnyFile(multipartFile);
+        } catch (IOException e) {
+            throw new BusinessLogicException(ExceptionCode.FILE_UPLOAD_FAILED);
+        }
+    }
 
 
 }

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/ImageService.java
@@ -8,9 +8,14 @@ import com.funding.backend.domain.projectImage.repository.ProjectImageRepository
 import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.binary.Hex;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -97,6 +102,41 @@ public class ImageService {
             throw new BusinessLogicException(ExceptionCode.FILE_UPLOAD_FAILED);
         }
     }
+
+
+    public String getETagFromFileUrl(String fileUrl) {
+        return s3Uploader.getETag(fileUrl);
+    }
+
+    public String calculateETag(MultipartFile file) throws IOException {
+        // 일반적으로 MD5 기반
+        try (InputStream is = file.getInputStream()) {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = is.read(buffer)) != -1) {
+                md.update(buffer, 0, bytesRead);
+            }
+            byte[] digest = md.digest();
+            return Hex.encodeHexString(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new BusinessLogicException(ExceptionCode.ETAG_HASH_FAILED);
+        }
+    }
+
+    public String generateFileHash(String originalFileName, long fileSize, String contentType) {
+        String input = originalFileName + fileSize + contentType;
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return Hex.encodeHexString(digest);  // Apache Commons Codec
+        } catch (NoSuchAlgorithmException e) {
+            throw new BusinessLogicException(ExceptionCode.MD5_HASH_FAILED);
+        }
+    }
+
+
+
 
 
 }

--- a/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
+++ b/backend/src/main/java/com/funding/backend/global/utils/s3/S3Uploader.java
@@ -137,7 +137,7 @@ public class S3Uploader {
 
                     orderedResult.add(uploaded);
                 } catch (IOException e) {
-                    throw new RuntimeException("파일 업로드 실패: " + originalName, e);
+                    throw new BusinessLogicException(ExceptionCode.FILE_UPLOAD_FAILED);
                 }
             }
         }


### PR DESCRIPTION
## 📒 개요

프로젝트 구매(리워드) 관련 기능을 구현하고, `ProvidingMethod` 기반의 다운로드 파일 처리 구조로 확장했습니다.  
프로젝트 구매 옵션(PurchaseOption)에 대한 CRUD 전체 기능을 완료했습니다.

<br>

## 📍 Issue 번호

> closed #Issue_number

<br>

## 🛠️ 작업사항

- ✅ **프로젝트 구매(Purchase) 생성 기능 구현**
  - 프로젝트 ID 기준으로 구매 엔티티 생성
  - 순환 참조 방지를 위한 별도 검증 메서드 구성

- ✅ **ProvidingMethod Enum 기반 구조 설계**
  - 리워드 지급 방식으로 `DOWNLOAD`, `DELIVERY` 등 추가
  - 다운로드 방식일 경우 업로드 파일 처리 방식 설계

- ✅ **구매 옵션(PurchaseOption) CRUD 구현**
  - **생성 (POST)**: `@ModelAttribute`를 통해 폼 + 파일 동시 전달  
    - 입력: 이름, 설명, 가격, 제공방식(DOWNLOAD/DELIVERY), 식별자(fileIdentifier), 파일(Multipart)
  - **조회 (GET)**: 프로젝트 ID로 전체 옵션 리스트 조회
  - **수정 (PUT)**: 선택적으로 파일 포함한 정보 수정
  - **삭제 (DELETE)**: 옵션 ID로 단일 삭제

- ✅ **파일 매칭 및 저장 로직 구현**
  - `fileIdentifier`와 업로드된 파일명을 매핑하여 DTO에 S3 URL, 파일명 등 저장
  - 파일 수 불일치 혹은 매칭 실패 시 예외 처리

- ✅ 응답 통일을 위한 `ApiResponse` 구조 사용  
  - `statusCode`, `message`, `timestamp` 포함

<br>

## 📸 스크린샷(선택)

> (선택 사항: Postman 요청/응답 캡처 또는 화면 캡처 추가)
<img width="1079" alt="스크린샷 2025-07-08 오후 11 41 27" src="https://github.com/user-attachments/assets/79513f03-2cc3-40f5-9111-01dabf821eef" />
