### PR TITLE
[ Feat ] : 34 사용자정보 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -51,6 +51,8 @@ dependencies {
     // redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    //email 인증
+    implementation("org.springframework.boot:spring-boot-starter-mail")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/funding/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/controller/UserController.java
@@ -1,29 +1,109 @@
 package com.funding.backend.domain.user.controller;
 
+import com.funding.backend.domain.user.dto.request.UserAccountInfo;
+import com.funding.backend.domain.user.dto.request.UserProfileUpdateRequest;
 import com.funding.backend.domain.user.dto.response.UserInfoResponse;
+import com.funding.backend.domain.user.dto.response.UserProfileResponse;
+import com.funding.backend.domain.user.email.service.EmailService;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.domain.user.repository.UserRepository;
+import com.funding.backend.domain.user.service.UserService;
 import com.funding.backend.security.jwt.RefreshTokenService;
 import com.funding.backend.security.jwt.TokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
+@Tag(name = "회원 정보 API")
 public class UserController {
 
     private final TokenService tokenService;
-    private final UserRepository userRepository;
     private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+    private final UserService userService;
+    private final EmailService emailService;
+
+    @GetMapping("/mypage")
+    @Operation(summary = "마이페이지 사용자 정보 조회", description = "사용자의 정보를 조회합니다.")
+    public ResponseEntity<UserProfileResponse> getMyPage() {
+        Long userId = tokenService.getUserIdFromAccessToken();
+        return ResponseEntity.ok(userService.getMyProfile(userId));
+    }
+
+    @PutMapping(value = "/mypage", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "마이페이지 사용자 정보 수정", description = "사용자의 정보를 수정합니다.")
+    public ResponseEntity<Void> updateMyPage(@RequestPart("info") UserProfileUpdateRequest request,
+                                             @RequestPart(value = "image", required = false) MultipartFile imageFile) {
+        Long userId = tokenService.getUserIdFromAccessToken();
+        userService.updateUserProfile(userId, request, imageFile);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/check-email")
+    @Operation(summary = "이메일 중복 확인", description = "사용자의 이메일 정보를 수정시 중복 확인을 합니다.")
+    public ResponseEntity<Boolean> checkEmail(@RequestParam(name = "email") String email) {
+        boolean exists = userService.checkEmailDuplication(email);
+        return ResponseEntity.ok(exists);
+    }
+
+    @PostMapping("/send-verification")
+    @Operation(summary = "이메일 인증 코드 메일 전송", description = "사용자의 이메일 정보를 수정시 이메일 인증 확인을 위해 인증 코드 메일을 전송합니다.")
+    public ResponseEntity<Void> sendVerification(@RequestParam(name = "email") String email) {
+        emailService.sendVerificationCode(email);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/verify-code")
+    @Operation(summary = "이메일 인증 코드 검증", description = "사용자의 이메일 정보를 수정시 입력한 이메일 인증 코드를 검증합니다.")
+    public ResponseEntity<Boolean> verifyCode(@RequestParam(name = "email") String email,
+                                              @RequestParam(name = "code") String code) {
+        boolean result = emailService.verifyCode(email, code);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/mypage/account")
+    @Operation(summary = "은행 정보 및 계좌 조회", description = "현재 로그인한 사용자의 은행명과 계좌번호를 조회합니다.")
+    public ResponseEntity<UserAccountInfo> getAccountInfo() {
+        Long userId = tokenService.getUserIdFromAccessToken();
+        UserAccountInfo response = userService.getBankInfo(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/mypage/account")
+    @Operation(summary = "은행 정보 및 계좌 등록/수정", description = "사용자의 은행명과 계좌번호를 등록하거나 수정합니다.")
+    public ResponseEntity<Void> updateAccountInfo(@RequestBody UserAccountInfo request) {
+        Long userId = tokenService.getUserIdFromAccessToken();
+        userService.updateBankInfo(userId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/mypage/account")
+    @Operation(summary = "은행 정보 및 계좌 삭제", description = "사용자의 은행명과 계좌번호를 삭제합니다.")
+    public ResponseEntity<Void> deleteAccountInfo() {
+        Long userId = tokenService.getUserIdFromAccessToken();
+        userService.deleteBankInfo(userId);
+        return ResponseEntity.ok().build();
+    }
 
     @GetMapping("/me")
+    @Operation(summary = "사용자 정보 전체 조회", description = "사용자의 모든 정보를 조회합니다.")
     public ResponseEntity<UserInfoResponse> getMyInfo(HttpServletRequest request) {
         Long userId = tokenService.getUserIdFromAccessToken();
 
@@ -35,6 +115,7 @@ public class UserController {
     }
 
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "쿠키/토큰 삭제")
     public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
         // 1. accessToken에서 userId 추출
         Long userId = tokenService.getUserIdFromAccessToken();

--- a/backend/src/main/java/com/funding/backend/domain/user/dto/request/UserAccountInfo.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/dto/request/UserAccountInfo.java
@@ -1,0 +1,17 @@
+package com.funding.backend.domain.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserAccountInfo {
+    private String bank;     // ex. 카카오뱅크
+    private String account;  // ex. 3333-01-1234567
+}

--- a/backend/src/main/java/com/funding/backend/domain/user/dto/request/UserProfileUpdateRequest.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.funding.backend.domain.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileUpdateRequest {
+    private String name;
+    private String email;
+    private String introduce;
+    private String portfolioAddress;
+}

--- a/backend/src/main/java/com/funding/backend/domain/user/dto/request/UserRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/dto/request/UserRequestDto.java
@@ -1,4 +1,0 @@
-package com.funding.backend.domain.user.dto.request;
-
-public class UserRequestDto {
-}

--- a/backend/src/main/java/com/funding/backend/domain/user/dto/response/UserProfileResponse.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,20 @@
+package com.funding.backend.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileResponse {
+    private String name;
+    private String email;
+    private String introduce;
+    private String portfolioAddress;
+    private String image;
+}

--- a/backend/src/main/java/com/funding/backend/domain/user/dto/response/UserResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/dto/response/UserResponseDto.java
@@ -1,4 +1,0 @@
-package com.funding.backend.domain.user.dto.response;
-
-public class UserResponseDto {
-}

--- a/backend/src/main/java/com/funding/backend/domain/user/email/dto/EmailVerification.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/email/dto/EmailVerification.java
@@ -1,0 +1,14 @@
+package com.funding.backend.domain.user.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailVerification {  // redis 임시 저장 용도
+    private String email;
+    private String code;
+    private boolean verified;
+}

--- a/backend/src/main/java/com/funding/backend/domain/user/email/service/EmailService.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/email/service/EmailService.java
@@ -1,0 +1,73 @@
+package com.funding.backend.domain.user.email.service;
+
+import com.funding.backend.domain.user.email.dto.EmailVerification;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final long EXPIRE_MINUTES = 5;
+
+    // 인증코드 메일 전송
+    public void sendVerificationCode(String email) {
+        String code = String.valueOf((int) ((Math.random() * 900000) + 100000)); // 6자리 숫자
+        EmailVerification verification = new EmailVerification(email, code, false);
+        redisTemplate.opsForValue().set("email:" + email, verification, Duration.ofMinutes(EXPIRE_MINUTES));
+
+        // 메일 전송
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
+
+            helper.setTo(email);
+            helper.setFrom("noreply@yetda.com", "YETDA 공식 메일"); // 이메일 + 이름
+            helper.setSubject("[YETDA] 이메일 인증 코드입니다.");
+
+            String html = "<div style='font-family: Arial, sans-serif; font-size: 16px;'>"
+                    + "<p>안녕하세요, YETDA입니다 😊</p>"
+                    + "<p>아래 <strong>인증 코드</strong>를 입력해주세요:</p>"
+                    + "<div style='margin-top: 10px; padding: 10px; background: #f5f5f5; border-radius: 5px; font-size: 24px; text-align: center;'>"
+                    + code
+                    + "</div>"
+                    + "<p style='margin-top: 20px;'>이 코드는 <b>5분간</b> 유효합니다.</p>"
+                    + "</div>";
+
+            helper.setText(html, true); // HTML 형식
+
+            mailSender.send(mimeMessage);
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            throw new RuntimeException("이메일 전송 실패", e);
+        }
+    }
+
+    // 인증코드 검증
+    public boolean verifyCode(String email, String inputCode) {
+        EmailVerification stored = (EmailVerification) redisTemplate.opsForValue().get("email:" + email);
+        if (stored != null && stored.getCode().equals(inputCode)) {
+            stored.setVerified(true);
+            redisTemplate.opsForValue().set("email:" + email, stored, Duration.ofMinutes(3)); // 인증 완료 상태로 재저장
+            return true;
+        }
+        return false;
+    }
+
+    // 인증 여부 조회
+    public boolean isVerified(String email) {
+        EmailVerification stored = (EmailVerification) redisTemplate.opsForValue().get("email:" + email);
+        return stored != null && stored.isVerified();
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/repository/UserRepository.java
@@ -8,4 +8,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialIdAndSsoProvider(String socialId, String ssoProvider);
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/backend/src/main/java/com/funding/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/service/UserService.java
@@ -1,19 +1,111 @@
 package com.funding.backend.domain.user.service;
 
+import com.funding.backend.domain.user.dto.request.UserAccountInfo;
+import com.funding.backend.domain.user.dto.request.UserProfileUpdateRequest;
 import com.funding.backend.domain.user.dto.response.UserInfoResponse;
+import com.funding.backend.domain.user.dto.response.UserProfileResponse;
+import com.funding.backend.domain.user.email.service.EmailService;
+import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.domain.user.repository.UserRepository;
+import com.funding.backend.global.utils.s3.S3Uploader;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3Uploader s3Uploader;
+    private final EmailService emailService;
+
+    public UserProfileResponse getMyProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        return UserProfileResponse.builder()
+                .name(user.getName())
+                .email(user.getEmail())
+                .introduce(user.getIntroduce())
+                .portfolioAddress(user.getPortfolioAddress())
+                .image(user.getImage())
+                .build();
+    }
+
+    public void updateUserProfile(Long userId, UserProfileUpdateRequest request, MultipartFile imageFile) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        // 이메일 변경이 있는 경우
+        if (!user.getEmail().equals(request.getEmail())) {
+            if (userRepository.existsByEmail(request.getEmail())) {
+                throw new RuntimeException("이미 사용 중인 이메일입니다.");
+            }
+            if (!emailService.isVerified(request.getEmail())) {
+                throw new RuntimeException("이메일 인증이 필요합니다.");
+            }
+
+            user.setEmail(request.getEmail()); // 인증된 경우만 저장
+        }
+
+        // 이미지가 새로 업로드된 경우
+        if (imageFile != null && !imageFile.isEmpty()) {
+            // 이전 이미지 삭제
+            if (user.getImage() != null) {
+                s3Uploader.deleteFile(user.getImage());
+            }
+
+            try {
+                String imageUrl = s3Uploader.uploadFile(imageFile);
+                user.setImage(imageUrl);
+            } catch (IOException e) {
+                throw new RuntimeException("이미지 업로드 실패");
+            }
+        }
+
+        user.setName(request.getName());
+        user.setIntroduce(request.getIntroduce());
+        user.setPortfolioAddress(request.getPortfolioAddress());
+
+        userRepository.save(user);
+    }
+
+    public boolean checkEmailDuplication(String email) {
+        return userRepository.existsByEmail(email);
+    }
 
     public UserInfoResponse getUserInfo(Long userId) {
         return userRepository.findById(userId)
                 .map(UserInfoResponse::from)
                 .orElseThrow(() -> new RuntimeException("User not found"));
+    }
+
+    @Transactional(readOnly = true)
+    public UserAccountInfo getBankInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자 없음"));
+
+        return new UserAccountInfo(user.getBank(), user.getAccount());
+    }
+
+    @Transactional
+    public void updateBankInfo(Long userId, UserAccountInfo request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자 없음"));
+
+        user.setBank(request.getBank());
+        user.setAccount(request.getAccount());
+    }
+
+    @Transactional
+    public void deleteBankInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자 없음"));
+
+        user.setBank(null);
+        user.setAccount(null);
     }
 }

--- a/backend/src/main/java/com/funding/backend/global/config/EmailConfig.java
+++ b/backend/src/main/java/com/funding/backend/global/config/EmailConfig.java
@@ -1,0 +1,74 @@
+package com.funding.backend.global.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Slf4j
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @PostConstruct
+    public void checkLoaded() {
+        log.info("[EmailConfig] Loaded config: host={}, username={}, starttlsRequired={}", host, username,
+                starttlsRequired);
+    }
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+        return properties;
+    }
+}

--- a/backend/src/main/java/com/funding/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/funding/backend/global/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -27,14 +28,18 @@ public class RedisConfig {
     @Bean
     @Primary
     @Qualifier("redisTemplate")
-    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
-        // 💡 직렬화 명시
+        // key는 String, value는 JSON 직렬화
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
+        // hash도 동일하게 설정
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        
         template.afterPropertiesSet();
         return template;
     }

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -3,8 +3,26 @@ package com.funding.backend.global.exception;
 import lombok.Getter;
 
 public enum ExceptionCode {
+
+    // 토큰 누락
+    ACCESS_TOKEN_NOT_FOUND(401, "Access Token이 존재하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(401, "Refresh Token이 존재하지 않습니다."),
+    // 토큰 유효성 실패
+    INVALID_ACCESS_TOKEN(401, "Access Token이 유효하지 않습니다."),
+    INVALID_REFRESH_TOKEN(401, "Refresh Token이 유효하지 않습니다."),
+
+    // 사용자정보 예외 처리
+    USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),
+    NAME_CANNOT_BE_EMPTY(400, "이름은 공란일 수 없습니다."),
+    EMAIL_ALREADY_EXISTS(409, "이미 사용 중인 이메일입니다."),
+    EMAIL_NOT_VERIFIED(401, "이메일 인증이 필요합니다."),
+    EMAIL_SEND_FAILED(500, "이메일 인증 코드 전송에 실패했습니다."),
+    EMAIL_VERIFICATION_NOT_FOUND(404, "인증 요청이 존재하지 않습니다."),
+    EMAIL_VERIFICATION_FAILED(401, "인증 코드가 일치하지 않습니다."),
+    BANK_AND_ACCOUNT_REQUIRED(400, "은행명과 계좌번호를 모두 입력해야 합니다."),
+
     //프로젝트 예외 처리
-    PROJECT_NOT_FOUND(404,"존재하지 않는 프로젝트 입니다."),
+    PROJECT_NOT_FOUND(404, "존재하지 않는 프로젝트 입니다."),
     NOT_PROJECT_CREATOR(403, "해당 프로젝트의 생성자가 아닙니다."),
     INVALID_PROJECT_TYPE(400, "지원하지 않는 프로젝트 타입입니다."),
 
@@ -22,18 +40,16 @@ public enum ExceptionCode {
 
 
     //구매 옵션 예외처리
-    PURCHASE_OPTION_NOT_FOUND(404,"존재하지 않는 구매옵션 입니다."),
-    PURCHASE_OPTION_FILE_COUNT(404,"옵션 개수와 파일 개수가 일치하지 않습니다."),
+    PURCHASE_OPTION_NOT_FOUND(404, "존재하지 않는 구매옵션 입니다."),
+    PURCHASE_OPTION_FILE_COUNT(404, "옵션 개수와 파일 개수가 일치하지 않습니다."),
     UNSUPPORTED_PROVIDING_METHOD(400, "지원하지 않는 제공 방식입니다."),
     FILE_REQUIRED_FOR_DOWNLOAD_OPTION(400, "DOWNLOAD 방식의 구매 옵션에는 파일이 필수입니다."),
     PURCHASE_OPTION_FILE_NOT_FOUND(400, "해당 옵션에 매칭되는 파일을 찾을 수 없습니다."),
 
 
-
-
     //S3 예외 처리
     S3_DELETE_ERROR(404, "이미지를 삭제할 수 없습니다."),
-    IMAGE_NOT_FOUND(404,"이미지를 찾을 수 없습니다."),
+    IMAGE_NOT_FOUND(404, "이미지를 찾을 수 없습니다."),
     IMAGE_UPLOAD_FAILED(500, "이미지 업로드에 실패하였습니다."),
     FILE_UPLOAD_FAILED(500, "파일 업로드에 실패하였습니다."),
     INVALID_S3_URL_FORMAT(400, "잘못된 S3 URL 형식입니다."),
@@ -41,17 +57,14 @@ public enum ExceptionCode {
     MD5_HASH_FAILED(500, "MD5 해시 생성에 실패하였습니다."),
 
 
-
     //요금제 예외 처리
-    PRICING_PLAN_NOT_FOUND(404,"존재하지 않는 요금제 입니다");
-
-    ;
+    PRICING_PLAN_NOT_FOUND(404, "존재하지 않는 요금제 입니다");
 
     @Getter
-    private int status;
+    private final int status;
 
     @Getter
-    private String message;
+    private final String message;
 
     ExceptionCode(int code, String message) {
         this.status = code;

--- a/backend/src/main/java/com/funding/backend/security/controller/AuthController.java
+++ b/backend/src/main/java/com/funding/backend/security/controller/AuthController.java
@@ -1,11 +1,12 @@
 package com.funding.backend.security.controller;
 
 import com.funding.backend.enums.RoleType;
+import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.security.jwt.JwtTokenizer;
 import com.funding.backend.security.jwt.dto.request.TokenReissueRequest;
 import com.funding.backend.security.jwt.dto.response.TokenReissueResponse;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -24,32 +25,36 @@ public class AuthController {
 
     private final JwtTokenizer jwtTokenizer;
 
-    @Qualifier("redisTemplate") // 둘 중 하나 명시
-    private final RedisTemplate<String, String> redisTemplate;
+    @Qualifier("redisTemplate")
+    private final RedisTemplate<String, Object> redisTemplate;
+
 
     @PostMapping("/reissue")
     public ResponseEntity<TokenReissueResponse> reissue(@RequestBody TokenReissueRequest request) {
         String refreshToken = request.getRefreshToken();
         log.info("✅ 전달된 리프레시 토큰: {}", refreshToken);
 
-        // Bearer 제거
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_REFRESH_TOKEN);
+        }
+
         if (refreshToken.startsWith("Bearer ")) {
             refreshToken = refreshToken.substring(7);
         }
 
         if (!jwtTokenizer.validateRefreshToken(refreshToken)) {
-            throw new JwtException("Refresh Token이 유효하지 않습니다.");
+            throw new BusinessLogicException(ExceptionCode.INVALID_REFRESH_TOKEN);
         }
 
         Claims claims = jwtTokenizer.parseRefreshToken(refreshToken);
         Long userId = Long.valueOf(claims.get("userId").toString());
 
         String key = "refreshToken:" + userId;
-        String storedToken = redisTemplate.opsForValue().get(key);
+        String storedToken = (String) redisTemplate.opsForValue().get(key);
         log.info("✅ Redis 저장된 토큰: {}", storedToken);
 
         if (storedToken == null || !storedToken.equals(refreshToken)) {
-            throw new JwtException("Refresh Token이 유효하지 않습니다.");
+            throw new BusinessLogicException(ExceptionCode.INVALID_REFRESH_TOKEN);
         }
 
         String email = claims.getSubject();

--- a/backend/src/main/java/com/funding/backend/security/jwt/JwtAuthFilter.java
+++ b/backend/src/main/java/com/funding/backend/security/jwt/JwtAuthFilter.java
@@ -2,6 +2,8 @@ package com.funding.backend.security.jwt;
 
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.domain.user.repository.UserRepository;
+import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.exception.ExceptionCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -13,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -34,7 +35,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if (token != null && jwtTokenizer.validateAccessToken(token)) {
             Long userId = jwtTokenizer.getUserIdFromAccessToken(token);
             User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없음"));
+                    .orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
 
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     user, null, List.of(new SimpleGrantedAuthority(user.getRole().getRole().name()))

--- a/backend/src/main/java/com/funding/backend/security/jwt/TokenService.java
+++ b/backend/src/main/java/com/funding/backend/security/jwt/TokenService.java
@@ -1,5 +1,7 @@
 package com.funding.backend.security.jwt;
 
+import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.exception.ExceptionCode;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,7 +35,7 @@ public class TokenService {
             }
         }
 
-        throw new IllegalArgumentException("Access Token이 존재하지 않습니다.");
+        throw new BusinessLogicException(ExceptionCode.ACCESS_TOKEN_NOT_FOUND);
     }
 
     // 요청에서 RefreshToken을 추출
@@ -46,27 +48,18 @@ public class TokenService {
             }
         }
 
-        throw new IllegalArgumentException("Refresh Token이 존재하지 않습니다.");
+        throw new BusinessLogicException(ExceptionCode.REFRESH_TOKEN_NOT_FOUND);
     }
 
     // AccessToken에서 사용자 ID 추출
     public Long getUserIdFromAccessToken() {
         String token = getAccessToken();
-
-        if (token == null) {
-            throw new IllegalArgumentException("Access Token이 존재하지 않습니다.");
-        }
-
         return jwtTokenizer.getUserIdFromAccessToken(token);
     }
 
+    // AccessToken에서 사용자 Email 추출
     public String getEmailFromAccessToken() {
         String token = getAccessToken();
-
-        if (token == null) {
-            throw new IllegalArgumentException("Access Token이 존재하지 않습니다.");
-        }
-
         return jwtTokenizer.getEmailFromAccessToken(token);
     }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -71,8 +71,21 @@ spring:
       maximum-pool-size: 10
       data-source-properties:
         maxAllowedPacket: 134217728
-
-
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${spring.mail.username}
+    password: ${spring.mail.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
 
 logging:
   level:


### PR DESCRIPTION
## 📒 개요

마이페이지 사용자정보 구현

<br>

## 📍 #34 

> closed #34 
<br>

## 🛠️ 작업사항

마이페이지 사용자 정보 구현 
- 기본정보 조회/수정 (이름, 프사, 이메일, 소개글, 포트폴리오주소)
- 이메일 변경시 중복 불가 및 인증 필수 
- 은행정보/계좌 crud
- (은행정보/계좌 인증 필요시 추가 예정)

<br>

## 📸 스크린샷(선택)
<img width="612" alt="image" src="https://github.com/user-attachments/assets/aeca2790-503f-4794-b22a-41e17492fbcf" />
