### PR TITLE
[feat] 18 : QnA기능 구현

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/qna/controller/QnaController.java
+++ b/backend/src/main/java/com/funding/backend/domain/qna/controller/QnaController.java
@@ -1,4 +1,143 @@
 package com.funding.backend.domain.qna.controller;
 
+import com.funding.backend.domain.qna.dto.request.AnswerRequestDto;
+import com.funding.backend.domain.qna.dto.request.QnaRequestDto;
+import com.funding.backend.domain.qna.dto.response.AnswerResponseDto;
+import com.funding.backend.domain.qna.dto.response.QnaResponseDto;
+import com.funding.backend.domain.qna.service.QnaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/qna")
+@RequiredArgsConstructor
+@Tag(name = "QnA 관리", description = "QnA CRUD API")
 public class QnaController {
+
+    private final QnaService qnaService;
+
+    //QnA 전체조회
+    @Operation(summary = "QnA 전체조회", description = "모든 QnA를 조회")
+    @GetMapping
+    public ResponseEntity<Page<QnaResponseDto>> getAllQna(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(required = false) Long currentUserId){
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<QnaResponseDto> qnaPage = qnaService.findAllQna(pageable, currentUserId);
+
+        return ResponseEntity.ok(qnaPage);
+    }
+
+    //QnA 상세 조회
+    @Operation(summary = "QnA 상세조회", description = "qnaId로 특정 QnA 조회")
+    @GetMapping("/{qnaId}")
+    public ResponseEntity<QnaResponseDto> getQnaById(@PathVariable Long qnaId,
+                                                     @RequestParam(required = false) Long currentUserId){
+
+        QnaResponseDto qna = qnaService.findByQnaId(qnaId, currentUserId);
+        return  ResponseEntity.ok(qna);
+    }
+
+    //프로젝트별 QnA 조회
+    @Operation(summary = "프로젝트별 QnA 조회", description = "특정 프로젝트의 Qna 조회")
+    @GetMapping("/project/{projectId}")
+    public ResponseEntity<Page<QnaResponseDto>> getQnaByProject(
+            @PathVariable Long projectId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(required = false) long currentUserId){
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<QnaResponseDto> qnaPage =
+                qnaService.findQnaByProjectId(projectId, pageable, currentUserId);
+        return  ResponseEntity.ok(qnaPage);
+    }
+
+    //사용자별 QnA 조회
+    @Operation(summary = "사용자별 QnA 조회", description = "특정 사용자의 QnA를 조회")
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<Page<QnaResponseDto>> getQnaByUser(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(required = false) Long currentUserId){
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<QnaResponseDto> qnaPage = qnaService.findQnaByUserId(userId, pageable, currentUserId);
+
+        return ResponseEntity.ok(qnaPage);
+    }
+
+    //QnA 작성
+    @Operation(summary = "QnA 작성", description = "새로운 QnA를 작성")
+    @PostMapping
+    public ResponseEntity<QnaResponseDto> createQna(@Valid @RequestBody QnaRequestDto requestDto){
+
+        QnaResponseDto result = qnaService.createQna(requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    //QnA 수정
+    @Operation(summary = "QnA 수정", description = "기존 QnA를 수정")
+    @PutMapping("/{qnaId}")
+    public ResponseEntity<QnaResponseDto> updateQna(@PathVariable Long qnaId,
+                                                    @Valid @RequestBody QnaRequestDto requestDto){
+
+        QnaResponseDto result = qnaService.updateQna(qnaId, requestDto);
+        return ResponseEntity.ok(result);
+    }
+
+    //QnA 삭제
+    @Operation(summary = "QnA 삭제", description = "QnA 삭제")
+    @DeleteMapping("/{qnaId}")
+    public ResponseEntity<Void> deleteQna(@PathVariable Long qnaId, @RequestParam Long userId){
+
+        qnaService.deleteQna(qnaId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /*
+    답변 관련 API
+     */
+
+    //QnA 답변 작성
+    @Operation(summary = "QnA 답변 작성", description = "QnA에 답변 작성")
+    @PostMapping("/{qnaId}/answer")
+    public ResponseEntity<AnswerResponseDto> createAnswer(@PathVariable Long qnaId,
+                                                          @Valid @RequestBody AnswerRequestDto requestDto){
+
+        AnswerResponseDto result = qnaService.createAnswer(qnaId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    //QnA 답변 수정
+    @Operation(summary = "QnA 답변 수정", description = "QnA에 답변 수정")
+    @PutMapping("/{qnaId}/answer")
+    public ResponseEntity<AnswerResponseDto> updateAnswer(@PathVariable Long qnaId,
+                                                          @Valid @RequestBody AnswerRequestDto requestDto){
+
+        AnswerResponseDto result = qnaService.updateAnswer(qnaId, requestDto);
+        return  ResponseEntity.ok(result);
+    }
+
+    //QnA 답변 삭제
+    @Operation(summary = "QnA 답변 삭제", description = "QnA 답변 삭제")
+    @DeleteMapping("/{qnaId}/answer")
+    public ResponseEntity<Void> deleteAnswer(@PathVariable Long qnaId){
+
+        qnaService.deleteAnswer(qnaId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/funding/backend/domain/qna/dto/request/AnswerRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/qna/dto/request/AnswerRequestDto.java
@@ -7,12 +7,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class QnaRequestDto {
+public class AnswerRequestDto {
 
-    private String title;
-    private String content;
-    private Long projectId;
+    private String answer;
     private Long userId;
-    private boolean visibility;
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/qna/dto/response/AnswerResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/qna/dto/response/AnswerResponseDto.java
@@ -1,0 +1,21 @@
+package com.funding.backend.domain.qna.dto.response;
+
+import com.funding.backend.domain.qna.entity.Qna;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AnswerResponseDto {
+    private Long id;
+    private String answer;
+
+    public static AnswerResponseDto from(Qna qna){
+        return AnswerResponseDto.builder()
+                .id(qna.getId())
+                .answer(qna.getAnswer())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/qna/dto/response/QnaResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/qna/dto/response/QnaResponseDto.java
@@ -1,4 +1,34 @@
 package com.funding.backend.domain.qna.dto.response;
 
+import com.funding.backend.domain.qna.entity.Qna;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
 public class QnaResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private Long projectId;
+    private Long userId;
+    private boolean visibility;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static QnaResponseDto from(Qna qna){
+        return QnaResponseDto.builder()
+                .id(qna.getId())
+                .title(qna.getTitle())
+                .content(qna.getContent())
+                .projectId(qna.getProject().getId())
+                .userId(qna.getUser().getId())
+                .visibility(qna.isVisibility())
+                .createdAt(qna.getCreatedAt())
+                .build();
+    }
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/qna/entity/Qna.java
+++ b/backend/src/main/java/com/funding/backend/domain/qna/entity/Qna.java
@@ -1,16 +1,9 @@
 package com.funding.backend.domain.qna.entity;
 
 import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.global.auditable.Auditable;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,12 +27,23 @@ public class Qna extends Auditable {
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
 
-    @Column(name = "titme", length = 100, nullable = false)
-    private String title; // 오타로 보임 → title 로 수정 권장
+    //user(작성자) 추가
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "title", length = 100, nullable = false)
+    private String title;
 
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
 
     @Column(name = "visibility", nullable = false)
     private boolean visibility;
+
+    //답변 필드 추가
+    @Column(name = "answer", nullable = true)
+    private String answer;
+
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/qna/repository/QnaRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/qna/repository/QnaRepository.java
@@ -1,10 +1,22 @@
 package com.funding.backend.domain.qna.repository;
 
 import com.funding.backend.domain.qna.entity.Qna;
-import jakarta.persistence.criteria.CriteriaBuilder.In;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface QnaRepository extends JpaRepository<Qna, Long> {
+
+    List<Qna> findByProjectId(Long projectId);
+
+    List<Qna> findByUserId(Long userId);
+
+    // 페이징 처리를 위한 메서드 추가
+    Page<Qna> findAll(Pageable pageable);
+    Page<Qna> findByProjectId(Long projectId, Pageable pageable);
+    Page<Qna> findByUserId(Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/com/funding/backend/domain/qna/service/QnaService.java
+++ b/backend/src/main/java/com/funding/backend/domain/qna/service/QnaService.java
@@ -1,4 +1,219 @@
 package com.funding.backend.domain.qna.service;
 
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.project.repository.ProjectRepository;
+import com.funding.backend.domain.qna.dto.request.AnswerRequestDto;
+import com.funding.backend.domain.qna.dto.request.QnaRequestDto;
+import com.funding.backend.domain.qna.dto.response.AnswerResponseDto;
+import com.funding.backend.domain.qna.dto.response.QnaResponseDto;
+import com.funding.backend.domain.qna.entity.Qna;
+import com.funding.backend.domain.qna.repository.QnaRepository;
+import com.funding.backend.domain.user.entity.User;
+import com.funding.backend.domain.user.repository.UserRepository;
+import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
 public class QnaService {
+
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final QnaRepository qnaRepository;
+
+    /*
+    공개/비공개 여부 체크
+     */
+
+    //권한 체크
+    private boolean privateQna(Qna qna, Long currentUserId){
+        if (currentUserId == null){
+            return false;
+        }
+
+        //QnA 작성자 또는 프로젝트 작성자만 true
+        return qna.getUser().getId().equals(currentUserId) ||
+                qna.getProject().getUser().getId().equals(currentUserId);
+    }
+
+    //비공개 처리를 위한 DTO 후처리
+    private QnaResponseDto processPrivateContent(QnaResponseDto dto, Qna qna, Long currentUserId){
+
+        boolean canView = qna.isVisibility() || privateQna(qna, currentUserId);
+
+        if (!canView) {
+            return QnaResponseDto.builder()
+                    .id(dto.getId())
+                    .title("비공개 질문입니다.")
+                    .content("")
+                    .projectId(dto.getProjectId())
+                    .userId(dto.getUserId())
+                    .visibility(dto.isVisibility())
+                    .createdAt(dto.getCreatedAt())
+                    .modifiedAt(dto.getModifiedAt())
+                    .build();
+        }
+        return dto;
+    }
+
+
+    /*
+    QnA 관련 기능
+     */
+
+    //QnA 상세 조회
+    @Transactional(readOnly = true)
+    public QnaResponseDto findByQnaId(Long qnaId, Long currentUserId) {
+        Qna qna = qnaRepository.findById(qnaId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.QNA_NOT_FOUND));
+
+        QnaResponseDto dto = QnaResponseDto.from(qna);
+
+        return processPrivateContent(dto,qna,currentUserId);
+    }
+
+    //전체 QnA 조회
+    @Transactional(readOnly = true)
+    public Page<QnaResponseDto> findAllQna(Pageable pageable, Long currentUserId){
+        Page<Qna> qnaPage = qnaRepository.findAll(pageable);
+
+        return  qnaPage.map(qna -> {
+            QnaResponseDto dto = QnaResponseDto.from(qna);
+            return processPrivateContent(dto, qna, currentUserId);
+        });
+    }
+
+    //프로젝트별 QnA 조회
+    @Transactional(readOnly = true)
+    public Page<QnaResponseDto> findQnaByProjectId(Long projectId, Pageable pageable, Long currentUserId){
+        projectRepository.findById(projectId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PROJECT_NOT_FOUND));
+
+        Page<Qna> qnaPage = qnaRepository.findByProjectId(projectId, pageable);
+
+        return  qnaPage.map(qna -> {
+            QnaResponseDto dto = QnaResponseDto.from(qna);
+            return processPrivateContent(dto, qna, currentUserId);
+        });
+    }
+
+
+    //사용자별 QnA 조회
+    @Transactional(readOnly = true)
+    public Page<QnaResponseDto> findQnaByUserId(Long userId, Pageable pageable, Long currentUserId){
+        userRepository.findById(userId)
+                .orElseThrow(()-> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Page<Qna> qnaPage = qnaRepository.findByUserId(userId, pageable);
+
+        return  qnaPage.map(qna -> {
+            QnaResponseDto dto = QnaResponseDto.from(qna);
+            return processPrivateContent(dto, qna, currentUserId);
+        });
+
+    }
+
+    //QnA 작성
+    @Transactional
+    public QnaResponseDto createQna(QnaRequestDto requestDto){
+        User user = userRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Project project = projectRepository.findById(requestDto.getProjectId())
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PROJECT_NOT_FOUND));
+
+        Qna qna = Qna.builder()
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .visibility(requestDto.isVisibility())
+                .user(user)
+                .project(project)
+                .build();
+
+        return QnaResponseDto.from(qnaRepository.save(qna));
+    }
+
+    //QnA 수정
+    @Transactional
+    public QnaResponseDto updateQna(Long qnaId, QnaRequestDto requestDto){
+        Qna qna = qnaRepository.findById(qnaId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.QNA_NOT_FOUND));
+
+        if (!qna.getUser().getId().equals(requestDto.getUserId())){
+            throw new RuntimeException("수정 권한이 없습니다.");
+        }
+
+        qna.setTitle(requestDto.getTitle());
+        qna.setContent(requestDto.getContent());
+        qna.setVisibility(requestDto.isVisibility());
+
+        return QnaResponseDto.from(qna);
+    }
+
+    //QnA 삭제
+    @Transactional
+    public void deleteQna(Long qnaId, Long userId){
+        Qna qna = qnaRepository.findById(qnaId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.QNA_NOT_FOUND));
+
+        if(!qna.getUser().getId().equals(userId)){
+            throw new RuntimeException("삭제 권한이 없습니다.");
+        }
+
+        qnaRepository.delete(qna);
+    }
+
+    /*
+    답변 관련 기능
+     */
+
+    //답변 작성
+    @Transactional
+    public AnswerResponseDto createAnswer(Long qnaId, AnswerRequestDto requestDto){
+        Qna qna = qnaRepository.findById(qnaId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.QNA_NOT_FOUND));
+
+        if(StringUtils.hasText(qna.getAnswer())){
+            throw new BusinessLogicException(ExceptionCode.ANSWER_ALREADY_EXISTS);
+        }
+
+        qna.setAnswer(requestDto.getAnswer());
+        Qna save = qnaRepository.save(qna);
+        return AnswerResponseDto.from(save);
+    }
+
+    //답변 수정
+    @Transactional
+    public AnswerResponseDto updateAnswer(Long qnaId, AnswerRequestDto requestDto){
+        Qna qna = qnaRepository.findById(qnaId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.QNA_NOT_FOUND));
+
+        if(!StringUtils.hasText(qna.getAnswer())){
+            throw new BusinessLogicException(ExceptionCode.ANSWER_NOT_FOUND);
+        }
+
+        qna.setAnswer(requestDto.getAnswer());
+        Qna save = qnaRepository.save(qna);
+        return AnswerResponseDto.from(save);
+    }
+
+    //답변 삭제(answer필드 null 처리)
+    @Transactional
+    public void deleteAnswer(Long qnaId){
+        Qna qna = qnaRepository.findById(qnaId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.QNA_NOT_FOUND));
+
+        if(!StringUtils.hasText(qna.getAnswer())){
+            throw new BusinessLogicException(ExceptionCode.ANSWER_NOT_FOUND);
+        }
+
+        qna.setAnswer(null);
+        qnaRepository.save(qna);
+    }
 }

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -40,6 +40,10 @@ public enum ExceptionCode {
     ETAG_HASH_FAILED(500, "ETag 해시 계산에 실패하였습니다."),
     MD5_HASH_FAILED(500, "MD5 해시 생성에 실패하였습니다."),
 
+    //QnA 예외 처리
+    QNA_NOT_FOUND(404, "존재하지 않는 QnA입니다."),
+    ANSWER_NOT_FOUND(404, "답변이 존재하지 않습니다."),
+    ANSWER_ALREADY_EXISTS(409, "이미 답변이 존재합니다."),
 
 
     //요금제 예외 처리


### PR DESCRIPTION
## 📒 개요

QnA 및 QnA 답변을 작성, 수정, 삭제, 조회할 수 있습니다.
질문에 1개의 답변을 할 수 있으며, 공개/비공개 설정으로 권한을 부여 했습니다.
추후 인증 관련 추가 필요합니다.

<br>

## 📍 Issue 번호

#18 

> closed #18 

<br>

## 🛠️ 작업사항

- 엔티티에 작성자 및 답변 필드 추가
- QnA CRUD 기능 구현
- 답변 관리 기능 구현
- 공개/비공개 권한 처리 로직 구현
- 페이징 처리

<br>

## 📸 스크린샷(선택)
<img width="1236" height="616" alt="image" src="https://github.com/user-attachments/assets/a037bef2-e199-4f81-becc-2dcffa374468" />
