### PR TITLE
[ feat ] 44 : 구매 옵션 기능 사용시 사용자 본인이 아니면 기능 사용 불가

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/project/entity/Project.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/entity/Project.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,8 +75,8 @@ public class Project extends Auditable {
     @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE, orphanRemoval = false)
     List<ProjectImage> projectImage = new ArrayList<>();
 
-    @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE, orphanRemoval = false)
-    List<Purchase> purchaseList = new ArrayList<>();
+    @OneToOne(mappedBy = "project", cascade = CascadeType.REMOVE)
+    private Purchase purchase;
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE, orphanRemoval = false)
     List<Notice> noticeList = new ArrayList<>();

--- a/backend/src/main/java/com/funding/backend/domain/purchase/entity/Purchase.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/entity/Purchase.java
@@ -19,6 +19,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,10 +42,9 @@ public class Purchase extends Auditable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id", nullable = false)
+    @OneToOne
+    @JoinColumn(name = "project_id", nullable = false, unique = true) // FK + unique 제약
     private Project project;
-
 
     @Column(name = "git_address", nullable = false)
     private String gitAddress;

--- a/backend/src/main/java/com/funding/backend/domain/purchase/repository/PurchaseRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/repository/PurchaseRepository.java
@@ -2,12 +2,18 @@ package com.funding.backend.domain.purchase.repository;
 
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.purchase.entity.Purchase;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PurchaseRepository extends JpaRepository<Purchase,Long> {
 
     Optional<Purchase> findByProject(Project project);
+
+    @Query("SELECT p FROM Purchase p JOIN p.purchaseOptionList po WHERE po.id = :purchaseOptionId")
+    Optional<Purchase> findByPurchaseOptionId(@Param("purchaseOptionId") Long purchaseOptionId);
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchaseOption/repository/PurchaseOptionRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseOption/repository/PurchaseOptionRepository.java
@@ -11,4 +11,5 @@ public interface PurchaseOptionRepository extends JpaRepository<PurchaseOption,L
     void deleteByPurchase(Purchase purchase);
     List<PurchaseOption> findAllByPurchase(Purchase purchase);
 
+
 }

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -16,6 +16,8 @@ public enum ExceptionCode {
     PURCHASE_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 입니다. "),
     INVALID_PROVIDING_METHOD(400, "제공 방식이 유효하지 않습니다."),
 
+    //사용자 예외처리
+    USER_NOT_FOUND(404,"존재하지 않는 유저 입니다."),
 
     //구매 카테고리 예외처리
     PURCHASE_CATEGORY_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 카테고리 입니다. "),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     ansi:
       enabled: ALWAYS
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE}
+    active: dev
     include: secret
   jackson:
     time-zone: Asia/Seoul


### PR DESCRIPTION
## 📒 개요

구매 옵션 생성/사용 시 로그인한 사용자가 해당 프로젝트의 생성자인지 식별하는 로직을 추가했습니다.
이를 통해 타인이 다른 사용자의 프로젝트에 구매 옵션을 생성하는 행위를 방지합니다.

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#44 
> closed #Issue_number

<br>

## 🛠️ 작업사항

- 프로젝트 생성자 식별 메서드 분리 및 적용
- createPurchaseOption() 내 사용자 검증 로직 추가
- 본인이 아닌 경우 NOT_PROJECT_CREATOR 예외 발생

<br>

## 📸 스크린샷(선택)
