### PR TITLE
[ feat ] 65 :  본인이 결제 또는 후원한 프로젝트 조회 기능, 본인이 구매한 프로젝트 내역 조회 기능

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/controller/OrderController.java
@@ -7,7 +7,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -34,10 +36,9 @@ public class OrderController {
             description = "사용자가 구매한 주문 목록을 페이지네이션 방식으로 조회합니다.( 기부형, 창작물형 포함) "
     )
     public ResponseEntity<ApiResponse<Page<OrderResponseDto>>> getUserOrderList(
-            @RequestParam(name = "page", defaultValue = "1") int page,
-            @RequestParam(name = "size", defaultValue = "10") int size) {
+            @ParameterObject Pageable pageable) {
 
-        Page<OrderResponseDto> response = orderService.getUserOrderListResponse(page, size);
+        Page<OrderResponseDto> response = orderService.getUserOrderListResponse(pageable);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.of(HttpStatus.CREATED.value(), "유저 구매 리스트 조회 완료",response));

--- a/backend/src/main/java/com/funding/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/controller/OrderController.java
@@ -1,0 +1,47 @@
+package com.funding.backend.domain.order.controller;
+
+import com.funding.backend.domain.order.dto.response.OrderResponseDto;
+import com.funding.backend.domain.order.service.OrderService;
+import com.funding.backend.global.utils.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/v1/order")
+@Validated
+@AllArgsConstructor
+@Tag(name = "구매 내역 관리 컨트롤러")
+@Slf4j
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @GetMapping
+    @Operation(
+            summary = "사용자 주문(구매 내역) 목록 조회",
+            description = "사용자가 구매한 주문 목록을 페이지네이션 방식으로 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<Page<OrderResponseDto>>> getUserOrderList(
+            @RequestParam(name = "page", defaultValue = "1") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+
+        Page<OrderResponseDto> response = orderService.getUserOrderList(page, size);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.of(HttpStatus.CREATED.value(), "유저 구매 리스트 조회 완료",response));
+    }
+
+
+}

--- a/backend/src/main/java/com/funding/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/controller/OrderController.java
@@ -31,13 +31,13 @@ public class OrderController {
     @GetMapping
     @Operation(
             summary = "사용자 주문(구매 내역) 목록 조회",
-            description = "사용자가 구매한 주문 목록을 페이지네이션 방식으로 조회합니다."
+            description = "사용자가 구매한 주문 목록을 페이지네이션 방식으로 조회합니다.( 기부형, 창작물형 포함) "
     )
     public ResponseEntity<ApiResponse<Page<OrderResponseDto>>> getUserOrderList(
             @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "size", defaultValue = "10") int size) {
 
-        Page<OrderResponseDto> response = orderService.getUserOrderList(page, size);
+        Page<OrderResponseDto> response = orderService.getUserOrderListResponse(page, size);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.of(HttpStatus.CREATED.value(), "유저 구매 리스트 조회 완료",response));

--- a/backend/src/main/java/com/funding/backend/domain/order/controller/PurchaseOrderController.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/controller/PurchaseOrderController.java
@@ -9,11 +9,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/order/purchase")
 @Validated
 @AllArgsConstructor
-@Tag(name = "프로젝트 구매내역 관리 컨트롤러")
+@Tag(name = "창작물 구매 관리 컨트롤러")
 @Slf4j
 public class PurchaseOrderController {
 
@@ -43,5 +45,7 @@ public class PurchaseOrderController {
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.of(HttpStatus.CREATED.value(), "구매 주문 생성 성공",response));
     }
+
+
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/order/controller/PurchaseOrderController.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/controller/PurchaseOrderController.java
@@ -4,6 +4,7 @@ package com.funding.backend.domain.order.controller;
 import com.funding.backend.domain.order.dto.request.PurchaseOrderRequestDto;
 import com.funding.backend.domain.order.dto.response.PurchaseOrderResponseDto;
 import com.funding.backend.domain.order.service.PurchaseOrderService;
+import com.funding.backend.domain.project.dto.response.ProjectResponseDto;
 import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,6 +12,9 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -45,6 +49,22 @@ public class PurchaseOrderController {
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.of(HttpStatus.CREATED.value(), "구매 주문 생성 성공",response));
     }
+
+    @GetMapping
+    @Operation(
+            summary = "사용자가 결제한 창작물 프로젝트 리스트 조회 ",
+            description = "사용자가 결제한 창작물 프로젝트 리스트를 조회합니다. "
+    )
+    @PreAuthorize("hasAnyRole('ADMIN','USER')")
+    public ResponseEntity<ApiResponse<Page<ProjectResponseDto>>> getPurchaseProjectList(
+            @ParameterObject Pageable pageable
+    ) {
+        Page<ProjectResponseDto> response = purchaseOrderService.getPurchaseProjectList(pageable);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "결제 프로젝트 리스트 조회 완료",response));
+    }
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/order/dto/response/OrderResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/dto/response/OrderResponseDto.java
@@ -1,0 +1,55 @@
+package com.funding.backend.domain.order.dto.response;
+
+import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.orderOption.dto.response.OrderOptionResponseDto;
+import com.funding.backend.enums.ProjectType;
+import com.funding.backend.global.toss.enums.PayType;
+import com.funding.backend.global.toss.enums.TossPaymentStatus;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderResponseDto {
+    private String orderId;
+    private TossPaymentStatus orderStatus;
+    private PayType payType;
+    private Long paidAmount;
+    private ProjectType projectType;
+    private String customerName;
+    private String customerEmail;
+
+    private String projectTitle; // 프로젝트 명 (선택)
+
+    //구매형일때만 정보 return
+    private List<OrderOptionResponseDto> orderOptions;
+
+    public static OrderResponseDto from(Order order) {
+        List<OrderOptionResponseDto> optionDtos = null;
+
+        if (order.getProjectType() != ProjectType.DONATION) {
+            optionDtos = order.getOrderOptionList().stream()
+                    .map(OrderOptionResponseDto::from)
+                    .toList();
+        }
+
+        return OrderResponseDto.builder()
+                .orderId(order.getOrderId())
+                .orderStatus(order.getOrderStatus())
+                .payType(order.getPayType())
+                .paidAmount(order.getPaidAmount())
+                .customerName(order.getCustomerName())
+                .customerEmail(order.getCustomerEmail())
+                .projectType(order.getProjectType())
+                .projectTitle(order.getProject() != null ? order.getProject().getTitle() : null)
+                .orderOptions(optionDtos)
+                .build();
+    }
+
+
+}

--- a/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
@@ -64,6 +64,9 @@ public class Order extends Auditable {
 	@Column(nullable = false)
 	private String customerName;
 
+	@Column(nullable = false)
+	private String orderName;
+
 	//Toss 결제 승인 시 받은 고유 키
 	@Column(name = "payment_key", unique = true)
 	private String paymentKey;

--- a/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
@@ -2,11 +2,26 @@ package com.funding.backend.domain.order.repository;
 
 
 import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.user.entity.User;
+import com.funding.backend.global.toss.enums.TossPaymentStatus;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order,Long> {
     Optional<Order> findByOrderId(String orderId);
+
+    @Query("SELECT o FROM Order o WHERE o.user = :user AND o.orderStatus = :status")
+    Page<Order> findOrdersByUserAndStatus(
+            @Param("user") User user,
+            @Param("status") TossPaymentStatus status,
+            Pageable pageable
+    );
+
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,7 +44,7 @@ public class OrderService {
         orderRepository.delete(order);
     }
 
-    public Page<OrderResponseDto> getUserOrderList(int page, int size) {
+    public Page<OrderResponseDto> getUserOrderListResponse(int page, int size) {
         PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         User loginUser = userService.findUserById(tokenService.getUserIdFromAccessToken());
 
@@ -52,7 +53,9 @@ public class OrderService {
         return orderPage.map(OrderResponseDto::from);
     }
 
+    public Page<Order> getUserOrderList(Pageable pageable) {
+        User loginUser = userService.findUserById(tokenService.getUserIdFromAccessToken());
 
-
-
+        return orderRepository.findOrdersByUserAndStatus(loginUser, TossPaymentStatus.DONE, pageable);
+    }
 }

--- a/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
@@ -44,11 +44,10 @@ public class OrderService {
         orderRepository.delete(order);
     }
 
-    public Page<OrderResponseDto> getUserOrderListResponse(int page, int size) {
-        PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+    public Page<OrderResponseDto> getUserOrderListResponse(Pageable pageable) {
         User loginUser = userService.findUserById(tokenService.getUserIdFromAccessToken());
 
-        Page<Order> orderPage = orderRepository.findOrdersByUserAndStatus(loginUser, TossPaymentStatus.DONE, pageRequest);
+        Page<Order> orderPage = orderRepository.findOrdersByUserAndStatus(loginUser, TossPaymentStatus.DONE, pageable);
 
         return orderPage.map(OrderResponseDto::from);
     }

--- a/backend/src/main/java/com/funding/backend/domain/order/service/PurchaseOrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/PurchaseOrderService.java
@@ -3,13 +3,19 @@ package com.funding.backend.domain.order.service;
 import static com.funding.backend.global.utils.OrderUtils.generateOrderId;
 
 import com.funding.backend.domain.order.dto.request.PurchaseOrderRequestDto;
+import com.funding.backend.domain.order.dto.response.OrderResponseDto;
 import com.funding.backend.domain.order.dto.response.PurchaseOrderResponseDto;
 import com.funding.backend.domain.order.entity.Order;
 import com.funding.backend.domain.order.repository.OrderRepository;
 import com.funding.backend.domain.orderOption.service.OrderOptionService;
+import com.funding.backend.domain.project.dto.response.ProjectResponseDto;
+import com.funding.backend.domain.project.dto.response.PurchaseProjectResponseDto;
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.project.service.ProjectService;
+import com.funding.backend.domain.purchase.entity.Purchase;
+import com.funding.backend.domain.purchase.service.PurchaseService;
 import com.funding.backend.domain.purchaseOption.dto.response.PurchaseOptionDto;
+import com.funding.backend.domain.purchaseOption.dto.response.PurchaseOptionResponseDto;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.domain.user.service.UserService;
 import com.funding.backend.enums.ProjectType;
@@ -21,6 +27,8 @@ import com.funding.backend.security.jwt.TokenService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,10 +38,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PurchaseOrderService {
     private final OrderRepository orderRepository;
-    private final ProjectService projectService;
-    private final TokenService tokenService;
+
+
     private final UserService userService;
     private final OrderOptionService orderOptionService;
+    private final ProjectService projectService;
+    private final TokenService tokenService;
+    private final OrderService orderService;
+    private final PurchaseService purchaseService;
 
 
     //주문 내역서 생성
@@ -97,6 +109,25 @@ public class PurchaseOrderService {
                 //.paySuccessYn(order.getOrderStatus() == OrderStatus.COMPLETED ? "Y" : "N")
                 .build();
     }
+
+
+    public Page<ProjectResponseDto> getPurchaseProjectList(Pageable pageable) {
+        Page<Order> orderPage = orderService.getUserOrderList(pageable);
+
+        Page<ProjectResponseDto> projectDtoPage = orderPage.map(order -> {
+            Project project = projectService.findProjectById(order.getProject().getId());
+            return purchaseService.createPurchaseProjectResponse(project);
+        });
+
+        return projectDtoPage;
+    }
+
+
+
+
+
+
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/order/service/PurchaseOrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/PurchaseOrderService.java
@@ -79,6 +79,7 @@ public class PurchaseOrderService {
                         request.getCustomerEmail() != null ? request.getCustomerEmail() : user.getEmail()
                 )
                 .project(project)
+                .orderName(project.getTitle())
                 .user(user)
                 .projectType(request.getProjectType())
                 .orderStatus(TossPaymentStatus.READY)
@@ -96,6 +97,7 @@ public class PurchaseOrderService {
                 //.paySuccessYn(order.getOrderStatus() == OrderStatus.COMPLETED ? "Y" : "N")
                 .build();
     }
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/orderOption/dto/response/OrderOptionResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/orderOption/dto/response/OrderOptionResponseDto.java
@@ -1,0 +1,39 @@
+package com.funding.backend.domain.orderOption.dto.response;
+
+import com.funding.backend.domain.orderOption.entity.OrderOption;
+import com.funding.backend.enums.ProvidingMethod;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OrderOptionResponseDto {
+
+    private Long id;
+
+    private String optionName;
+
+    private Long price;
+
+    private ProvidingMethod providingMethod;
+
+    private LocalDateTime downloadExpire;
+
+    private Integer downloadCount;
+
+    public static OrderOptionResponseDto from(OrderOption option) {
+        return OrderOptionResponseDto.builder()
+                .id(option.getId())
+                .optionName(option.getOptionName())
+                .price(option.getPrice())
+                .providingMethod(option.getProvidingMethod())
+                .downloadExpire(option.getDownloadExpire())
+                .downloadCount(option.getDownloadCount())
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -1,6 +1,7 @@
 package com.funding.backend.global.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 public enum ExceptionCode {
 
@@ -46,6 +47,8 @@ public enum ExceptionCode {
     //구매 예외처리
     PURCHASE_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 입니다. "),
     INVALID_PROVIDING_METHOD(400, "제공 방식이 유효하지 않습니다."),
+    MISMATCHED_PAYMENT_AMOUNT(400, "결제 금액이 맞지 않습니다."),
+
 
     //사용자 예외처리
     PURCHASE_CATEGORY_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 카테고리 입니다. "),

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -43,6 +43,7 @@ public enum ExceptionCode {
 
     //주문 예외처리
     ORDER_NOT_FOUND(404, "존재하지 않는 구매 내역 입니다. "),
+    PAYMENT_CONFIRM_FAILED(400, "결제 승인 요청에 실패했습니다."),
 
     //구매 예외처리
     PURCHASE_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 입니다. "),

--- a/backend/src/main/java/com/funding/backend/global/toss/dto/response/TossPaymentsResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/global/toss/dto/response/TossPaymentsResponseDto.java
@@ -54,6 +54,8 @@ public class TossPaymentsResponseDto {
     private String version;
     private Object metadata;
 
+    @Getter
+    @NoArgsConstructor
     public static class Card {
         private String issuerCode;
         private String acquirerCode;
@@ -69,16 +71,22 @@ public class TossPaymentsResponseDto {
         private long amount;
     }
 
+    @Getter
+    @NoArgsConstructor
     public static class EasyPay {
         private String provider;
         private long amount;
         private long discountAmount;
     }
 
+    @Getter
+    @NoArgsConstructor
     public static class Receipt {
         private String url;
     }
 
+    @Getter
+    @NoArgsConstructor
     public static class Checkout {
         private String url;
     }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -9,4 +9,3 @@ spring:
       host: ${LOCAL_HOST}
       port: ${REDIS_EXTERNAL_PORT}
       password:
-

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -13,3 +13,4 @@ spring:
 custom:
   site:
     frontUrl: http://${LOCAL_HOST}:${FRONTEND_EXTERNAL_PORT}
+    backUrl: http://${LOCAL_HOST}:${SPRING_INTERNAL_PORT}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         default_batch_fetch_size: 100


### PR DESCRIPTION
## 📒 개요

본인이 결제하거나 후원한 프로젝트를 조회하는 기능과, 구매한 프로젝트 내역을 확인하는 기능을 구현했습니다.

<br>

## 📍 Issue 번호

> closed #65

<br>

## 🛠️ 작업사항

- 본인이 후원 또는 결제한 프로젝트 목록 조회 API 구현  
- 본인이 결제한 프로젝트 상세 내역 조회 API 구현  
- 정렬 및 페이징 기능 적용 (Pageable 활용)  
- 인증된 사용자만 접근 가능하도록 보안 설정 (@PreAuthorize)

<br>

## 📸 스크린샷(선택)

<img width="852" height="771" alt="스크린샷 2025-07-12 오후 8 04 59" src="https://github.com/user-attachments/assets/dea72025-668c-4fc6-8bb7-8e5a6790e375" />
<img width="852" height="771" alt="스크린샷 2025-07-12 오후 8 05 27" src="https://github.com/user-attachments/assets/e0718083-25e1-48b5-b246-a8db1c8bfd62" />






