### PR TITLE
[ fix ] 247 : 게시글 수정시 이미지 없어도 수정 가능하게 변경

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
@@ -108,11 +108,12 @@ public class ProjectService {
 
         // 프로젝트 상세 내용 업데이트
         project.setContent(purchaseUpdateRequestDto.getContent());
-
-        // 이미지 업데이트
-        List<ProjectImage> updatedImages = imageService.updateImageList
-                (project.getProjectImage(), purchaseUpdateRequestDto.getContentImage(), project);
-        project.setProjectImage(updatedImages);
+        if(purchaseUpdateRequestDto.getContentImage() != null && !purchaseUpdateRequestDto.getContentImage().isEmpty()){
+            // 이미지 업데이트
+            List<ProjectImage> updatedImages = imageService.updateImageList
+                    (project.getProjectImage(), purchaseUpdateRequestDto.getContentImage(), project);
+            project.setProjectImage(updatedImages);
+        }
         projectRepository.save(project);
         // Purchase 관련 필드 업데이트
         purchaseService.updatePurchase(project, purchaseUpdateRequestDto);


### PR DESCRIPTION
## 📒 개요

게시글 수정시 이미지 없어도 수정 가능하게 변경

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#247 
> closed #Issue_number

<br>

## 🛠️ 작업사항

게시글 수정시 이미지 없어도 수정 가능하게 변경

<br>

## 📸 스크린샷(선택)
