### PR TITLE
[ feat ] 256 : 구매 프로젝트 카테고리 별 조회 구현 완료

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
@@ -29,5 +29,13 @@ public interface OrderRepository extends JpaRepository<Order,Long> {
     @Query("SELECT COUNT(o) FROM Order o WHERE o.project.id = :projectId AND o.orderStatus = 'DONE'")
     Long countDoneOrdersByProjectId(@Param("projectId") Long projectId);
 
+        @Query("""
+        SELECT o.project.id, COUNT(o)
+        FROM Order o
+        WHERE o.project.id IN :projectIds
+        GROUP BY o.project.id
+    """)
+        List<Object[]> countOrdersByProjectIds(@Param("projectIds") List<Long> projectIds);
+
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
@@ -11,6 +11,7 @@ import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.global.toss.enums.TossPaymentStatus;
 import com.funding.backend.security.jwt.TokenService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -63,6 +64,11 @@ public class OrderService {
     //
     public Long purchaseOrderCount(Project project){
         return orderRepository.countDoneOrdersByProjectId(project.getId());
-
     }
+
+    public List<Object[]> countOrdersByProjectIds( List<Long> projectIds){
+        return orderRepository.countOrdersByProjectIds(projectIds);
+    }
+
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/repository/ProjectRepository.java
@@ -97,6 +97,18 @@ public interface ProjectRepository extends JpaRepository<Project,Long> {
     @EntityGraph(attributePaths = "purchase")
     Page<Project> findByUserIdAndProjectType(Long userId, ProjectType projectType, Pageable pageable);
 
+    @Query("""
+        SELECT p
+        FROM Project p
+        JOIN p.purchase pu
+        WHERE pu.purchaseCategory.id = :categoryId
+          AND p.projectStatus = :status
+    """)
+    Page<Project> findByPurchaseCategoryAndStatus(
+            @Param("categoryId") Long categoryId,
+            @Param("status") ProjectStatus status,
+            Pageable pageable
+    );
 
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchase/controller/PurchaseController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/controller/PurchaseController.java
@@ -1,16 +1,22 @@
 package com.funding.backend.domain.purchase.controller;
 
 import com.funding.backend.domain.project.dto.request.ProjectCreateRequestDto;
+import com.funding.backend.domain.project.dto.response.ProjectInfoResponseDto;
 import com.funding.backend.domain.project.dto.response.PurchaseProjectResponseDto;
 import com.funding.backend.domain.project.service.ProjectService;
 import com.funding.backend.domain.purchase.dto.request.PurchaseUpdateRequestDto;
+import com.funding.backend.domain.purchase.dto.response.PurchaseInfoResponseDto;
 import com.funding.backend.domain.purchase.dto.response.PurchaseListResponseDto;
 import com.funding.backend.domain.purchase.dto.response.PurchaseResponseDto;
 import com.funding.backend.domain.purchase.service.PurchaseService;
 import com.funding.backend.domain.purchaseOption.dto.response.PurchaseOptionResponseDto;
+import com.funding.backend.enums.PopularProjectSortType;
+import com.funding.backend.enums.ProjectStatus;
+import com.funding.backend.enums.ProjectTypeFilter;
 import com.funding.backend.enums.ProvidingMethod;
 import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -29,6 +35,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -99,6 +106,24 @@ public class PurchaseController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.of(HttpStatus.OK.value(), "내가 생성한 구매형 프로젝트 목록 조회 성공", projects));
+    }
+
+
+
+    @GetMapping("/category/{categoryId}")
+    @Operation(
+            summary = "카테고리별 구매 프로젝트 리스트 조회",
+            description = "카테고리별 구매 프로젝트 리스트 조회"
+    )
+    public ResponseEntity<ApiResponse<Page<PurchaseInfoResponseDto>>> getCategoryList(
+            @Parameter(description = "카테고리 ID") @PathVariable Long categoryId,
+            @RequestParam ProjectStatus projectStatus,
+            @ParameterObject Pageable pageable
+    ) {
+        Page<PurchaseInfoResponseDto> response = purchaseService.getPurchaseCategoryProjectList(categoryId, pageable, projectStatus);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "카테고리별 프로젝트 조회 성공", response));
     }
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/purchase/dto/response/PurchaseInfoResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchase/dto/response/PurchaseInfoResponseDto.java
@@ -1,0 +1,56 @@
+package com.funding.backend.domain.purchase.dto.response;
+
+import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.enums.ProjectType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PurchaseInfoResponseDto {
+
+    @Schema(description = "프로젝트 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "프로젝트 제목", example = "개발자 노션 포트폴리오")
+    private String title;
+
+    @Schema(description = "프로젝트 소개", example = "이 프로젝트는 개발자들의 노션 포트폴리오를 소개합니다.")
+    private String introduce;
+
+    @Schema(description = "프로젝트 썸네일 이미지 URL", example = "https://example.com/thumbnail.jpg")
+    private String projectFirstImage;
+
+    @Schema(description = "프로젝트 타입 (구매/기부)", example = "PURCHASE")
+    private ProjectType projectType;
+
+    @Schema(description = "프로젝트 좋아요 수", example = "150")
+    private int projectLikeCount;
+
+    @Schema(description = "구매 프로젝트의 구매 수", example = "200")
+    private Long sellingAmount;
+
+    @Schema(description = "제작자 ID", example = "145")
+    private Long hostId;
+
+    @Schema(description = "제작자 이름", example = "홍길동")
+    private String hostName;
+
+    @Schema(description = "제작자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    private String hostProfileImageUrl;
+
+    public PurchaseInfoResponseDto(Project project, Long sellingAmount) {
+        this.id = project.getId();
+        this.title = project.getTitle();
+        this.introduce = project.getIntroduce();
+        this.projectFirstImage = project.getProjectImage().isEmpty() ? null : project.getProjectImage().getFirst().getImageUrl();
+        this.projectType = project.getProjectType();
+        this.projectLikeCount = project.getLikeList() != null ? project.getLikeList().size() : 0;
+        this.sellingAmount = sellingAmount;
+        this.hostId = project.getUser().getId();
+        this.hostName = project.getUser().getName();
+        this.hostProfileImageUrl = project.getUser().getImage();
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/purchaseCategory/controller/CategoryController.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseCategory/controller/CategoryController.java
@@ -1,4 +1,0 @@
-package com.funding.backend.domain.purchaseCategory.controller;
-
-public class CategoryController {
-}

--- a/backend/src/main/java/com/funding/backend/domain/purchaseCategory/entity/PurchaseCategory.java
+++ b/backend/src/main/java/com/funding/backend/domain/purchaseCategory/entity/PurchaseCategory.java
@@ -30,7 +30,6 @@ import lombok.experimental.SuperBuilder;
 @ToString
 public class PurchaseCategory extends Auditable {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")

--- a/backend/src/main/java/com/funding/backend/global/config/YetdaSecurityConfig.java
+++ b/backend/src/main/java/com/funding/backend/global/config/YetdaSecurityConfig.java
@@ -51,6 +51,7 @@ public class YetdaSecurityConfig {
 
                         //프로젝트 (검색 포함됨)
                         .requestMatchers(HttpMethod.GET, "/api/v1/project/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/api/v1/project/purchase/category/**").permitAll()
 
                         //구매 프로젝트 CRUD
                         .requestMatchers(HttpMethod.GET, "/api/v1/project/purchase/**").permitAll()


### PR DESCRIPTION
## 📒 개요

카테고리별 구매 프로젝트 리스트 조회 API 구현  
- `categoryId`와 `projectStatus` 기준으로 프로젝트 목록 조회  
- 페이지네이션 및 정렬 기능 포함 (`Pageable`)  
- 각 프로젝트의 판매 수량(`sellingAmount`)을 N+1 없이 효율적으로 조회하도록 최적화  

<br>

## 📍 Issue 번호

> closed #123

<br>

## 🛠️ 작업사항

- `GET /api/v1/project/purchase/category/{categoryId}` API 구현  
- Query Parameter로 `projectStatus`, `page`, `size`, `sort` 지원  
- 판매 수량(N+1 문제 해결) → `orderRepository.countOrdersByProjectIds(...)` 한 번에 조회  
- DTO: `PurchaseInfoResponseDto(Project, sellingAmount)` 형태로 리팩토링  
- Swagger 문서화: `@Parameter`, `@Operation` 등 명세 설정 완료  

<br>

## 🧪 파라미터 예시
GET /api/v1/project/purchase/category/1?projectStatus=RECRUITING&page=0&size=5&sort=createdAt,desc



**Query Parameters 설명**
| 파라미터 | 설명 |
|----------|------|
| `categoryId` | 조회할 구매 카테고리의 ID |
| `projectStatus` | 프로젝트 상태 (`RECRUITING`, `COMPLETED`, `UNDER_AUDIT`, `REJECTED`) |
| `page` | 페이지 번호 (기본값: 0) |
| `size` | 페이지당 항목 수 (기본값: 20) |
| `sort` | 정렬 필드 및 방향 (예: `createdAt,desc`) |

<br>

## 📸 스크린샷

<img width="781" height="772" alt="스크린샷 2025-07-21 오후 4 58 49" src="https://github.com/user-attachments/assets/2f5b859b-71cc-43b0-8a3e-1c69fa5fca8f" />

