### PR TITLE
[ feat ] 266 : 정산 기능 관리자 사용자 포함

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/order/dto/response/OrderSettlementResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/dto/response/OrderSettlementResponseDto.java
@@ -1,0 +1,8 @@
+package com.funding.backend.domain.order.dto.response;
+
+
+import lombok.Getter;
+
+@Getter
+public class OrderSettlementResponseDto {
+}

--- a/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
@@ -2,6 +2,7 @@ package com.funding.backend.domain.order.entity;
 
 import com.funding.backend.domain.orderOption.entity.OrderOption;
 import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.settlement.entity.Settlement;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.enums.ProjectType;
 import com.funding.backend.global.auditable.Auditable;
@@ -12,6 +13,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -86,5 +88,11 @@ public class Order extends Auditable {
 
 	@OneToMany(mappedBy = "order")
 	private List<OrderOption> orderOptionList = new ArrayList<>();
+
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "settlement_id")
+	private Settlement settlement;
+
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
@@ -2,9 +2,11 @@ package com.funding.backend.domain.order.repository;
 
 
 import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.global.toss.enums.TossPaymentStatus;
 import io.lettuce.core.dynamic.annotation.Param;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -38,4 +40,12 @@ public interface OrderRepository extends JpaRepository<Order,Long> {
         List<Object[]> countOrdersByProjectIds(@Param("projectIds") List<Long> projectIds);
 
 
+
+    //정산에 포함되어야 할 주문은 '결제가 완료된 주문'만 포함
+    List<Order> findByProjectAndCreatedAtBetweenAndOrderStatus(
+            Project project,
+            LocalDateTime from,
+            LocalDateTime to,
+            TossPaymentStatus orderStatus
+    );
 }

--- a/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
@@ -11,6 +11,7 @@ import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.global.toss.enums.TossPaymentStatus;
 import com.funding.backend.security.jwt.TokenService;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +70,12 @@ public class OrderService {
 
     public Long donationOrderCount(Project project) {
         return orderRepository.countDoneOrdersByProjectId(project.getId());
+    }
+
+
+    //프로젝트 당 특정 기간동안 생성된 주문 확인 ( 주문 완료 된 것만)
+    public List<Order> findByProjectAndCreatedAtBetween(Project project,LocalDateTime from, LocalDateTime to, TossPaymentStatus tossPaymentStatus){
+        return orderRepository.findByProjectAndCreatedAtBetweenAndOrderStatus(project,from,to,tossPaymentStatus);
     }
 
 

--- a/backend/src/main/java/com/funding/backend/domain/project/entity/Project.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/entity/Project.java
@@ -11,6 +11,7 @@ import com.funding.backend.domain.order.entity.Order;
 import com.funding.backend.domain.pricingPlan.entity.PricingPlan;
 import com.funding.backend.domain.projectImage.entity.ProjectImage;
 import com.funding.backend.domain.purchase.entity.Purchase;
+import com.funding.backend.domain.settlement.entity.Settlement;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.enums.ProjectStatus;
 import com.funding.backend.enums.ProjectType;
@@ -94,5 +95,8 @@ public class Project extends Auditable {
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE, orphanRemoval = false)
     List<Order> orderList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE, orphanRemoval = false)
+    List<Settlement> settlementList = new ArrayList<>();
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/controller/SettlementController.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/controller/SettlementController.java
@@ -43,5 +43,4 @@ public class SettlementController {
                 .body(ApiResponse.of(HttpStatus.OK.value(), "정산 상세 조회 성공", response));
     }
 
-
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/controller/SettlementController.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/controller/SettlementController.java
@@ -1,0 +1,4 @@
+package com.funding.backend.domain.settlement.controller;
+
+public class SettlementController {
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/controller/SettlementController.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/controller/SettlementController.java
@@ -1,4 +1,47 @@
 package com.funding.backend.domain.settlement.controller;
 
+
+import com.funding.backend.domain.settlement.dto.response.SettlementDetailResponseDto;
+import com.funding.backend.domain.settlement.service.SettlementService;
+import com.funding.backend.global.utils.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/settlement")
+@Validated
+@AllArgsConstructor
+@Tag(name = "프로젝트 정산 관리 컨트롤러")
+@Slf4j
 public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    //구매 프로젝트 정산 관리
+    @GetMapping("/purchase/{projectId}")
+    @Operation(
+            summary = "구매형 프로젝트 정산 상세 조회",
+            description = "사용자가 자신의 구매형 프로젝트에 대해 가장 최근 정산 정보를 조회합니다. 후원형 프로젝트는 제외됩니다."
+    )
+    public ResponseEntity<ApiResponse<SettlementDetailResponseDto>> getLatestPurchaseSettlementDetail(
+            @PathVariable Long projectId
+    ) {
+        SettlementDetailResponseDto response = settlementService.getLatestPurchaseSettlementDetail(projectId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "정산 상세 조회 성공", response));
+    }
+
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/dto/request/SettlementRequestDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/dto/request/SettlementRequestDto.java
@@ -1,0 +1,4 @@
+package com.funding.backend.domain.settlement.dto.request;
+
+public class SettlementRequestDto {
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/OrderSummaryDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/OrderSummaryDto.java
@@ -1,0 +1,10 @@
+package com.funding.backend.domain.settlement.dto.response;
+
+import java.time.LocalDateTime;
+
+public class OrderSummaryDto {
+    private String orderId;
+    private String customerEmail;
+    private Long paidAmount;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/SettlementDetailResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/SettlementDetailResponseDto.java
@@ -1,0 +1,24 @@
+package com.funding.backend.domain.settlement.dto.response;
+
+import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.enums.SettlementStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SettlementDetailResponseDto {
+    private String projectTitle;
+    private LocalDateTime periodStart;
+    private LocalDateTime periodEnd;
+    private Long totalOrderAmount;
+    private Long feeAmount;
+    private Long payoutAmount;
+    private SettlementStatus settlementStatus;
+
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/SettlementResponoseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/SettlementResponoseDto.java
@@ -1,4 +1,0 @@
-package com.funding.backend.domain.settlement.dto.response;
-
-public class SettlementResponoseDto {
-}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/SettlementResponoseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/SettlementResponoseDto.java
@@ -1,0 +1,4 @@
+package com.funding.backend.domain.settlement.dto.response;
+
+public class SettlementResponoseDto {
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/entity/Settlement.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/entity/Settlement.java
@@ -1,4 +1,78 @@
 package com.funding.backend.domain.settlement.entity;
 
-public class Settlement {
+
+import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.user.entity.User;
+import com.funding.backend.enums.SettlementStatus;
+import com.funding.backend.global.auditable.Auditable;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "settlements")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class Settlement extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    // 해당 정산이 포함하는 기간 (예: 6월분 정산)
+    private LocalDateTime periodStart;
+    private LocalDateTime periodEnd;
+
+    // 정산 금액 정보
+    // 총 주문 금액
+    private Long totalOrderAmount;
+
+    //수수료 금액
+    private Long feeAmount;
+
+    //실제 정산 지급 금액
+    //totalOrderAmount - feeAmount
+    private Long payoutAmount;
+
+
+    //정산 완료 시간
+    private LocalDateTime settledAt;
+
+    @Enumerated(EnumType.STRING)
+    private SettlementStatus status; // WAITING, COMPLETED, FAILED 등
+
+    // 어떤 프로젝트에 대한 정산인지
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "settlement", cascade = CascadeType.ALL, orphanRemoval = false)
+    private List<Order> orderList = new ArrayList<>();
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/entity/Settlement.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/entity/Settlement.java
@@ -1,0 +1,4 @@
+package com.funding.backend.domain.settlement.entity;
+
+public class Settlement {
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/repository/SettlementRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/repository/SettlementRepository.java
@@ -1,4 +1,19 @@
 package com.funding.backend.domain.settlement.repository;
 
-public class SettlementRepository {
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.settlement.entity.Settlement;
+import com.funding.backend.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+
+    //특정 프로젝트에 대한 Settlement 중 가장 최근에 끝난 정산 하나 조회
+    Optional<Settlement> findTopByProjectOrderByPeriodEndDesc(Project project);
+
+
+    List<Settlement> findAllByProject(Project project);
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/repository/SettlementRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/repository/SettlementRepository.java
@@ -1,0 +1,4 @@
+package com.funding.backend.domain.settlement.repository;
+
+public class SettlementRepository {
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/service/SettlementService.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/service/SettlementService.java
@@ -1,4 +1,125 @@
 package com.funding.backend.domain.settlement.service;
 
+import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.order.service.OrderService;
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.project.service.ProjectService;
+import com.funding.backend.domain.settlement.dto.response.SettlementDetailResponseDto;
+import com.funding.backend.domain.settlement.entity.Settlement;
+import com.funding.backend.domain.settlement.repository.SettlementRepository;
+import com.funding.backend.domain.user.entity.User;
+import com.funding.backend.domain.user.service.UserService;
+import com.funding.backend.enums.ProjectType;
+import com.funding.backend.enums.SettlementStatus;
+import com.funding.backend.global.exception.BusinessLogicException;
+import com.funding.backend.global.exception.ExceptionCode;
+import com.funding.backend.global.toss.enums.TossPaymentStatus;
+import com.funding.backend.security.jwt.TokenService;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SettlementService {
+
+    @Value("${settlement.day}")
+    private Long settlementDay;
+
+    private final SettlementRepository settlementRepository;
+    private final OrderService orderService;
+
+    private final ProjectService projectService;
+    private final UserService userService;
+    private final TokenService tokenService;
+
+
+    //프로젝트 아이디를 입력하면, 해당 프로젝트에 대한 정산 내역을 제공
+    public SettlementDetailResponseDto getLatestPurchaseSettlementDetail(Long projectId){
+        Project project = projectService.findProjectById(projectId);
+        User loginUser = userService.findUserById(tokenService.getUserIdFromAccessToken());
+
+        //해당 메서드 사용하기 위한 유효성 검사 로직
+        validPurchaseSettlement(project,loginUser);
+        List<Settlement> settlementList = settlementRepository.findAllByProject(project);
+
+        if (settlementList == null || settlementList.isEmpty()) {
+            //정산 내역이 존재하지 않는다면
+            return getFromProjectCreation(project);
+        } else {
+
+            //정산 내역이 존재한다면
+            return getFromLatestSettlement(project, settlementList);
+        }
+    }
+
+
+    //정산 내역이 존재하지 않는다면 -> 프로젝트 생성일 기준, 현재 날짜 기준으로 제공
+    private SettlementDetailResponseDto getFromProjectCreation(Project project) {
+        LocalDateTime from = project.getCreatedAt();
+        LocalDateTime to = LocalDateTime.now();
+
+        List<Order> orders = orderService.findByProjectAndCreatedAtBetween(project, from, to, TossPaymentStatus.DONE);
+        return calculateSettlementDto(project, from, to, orders); // isPreview = true
+    }
+
+    //정산 내역이 존재한다면
+    private SettlementDetailResponseDto getFromLatestSettlement(Project project, List<Settlement> settlements) {
+        //이전 정산내역의 마지막 정산 날짜를 계산하고
+        Settlement latest = settlementRepository.findTopByProjectOrderByPeriodEndDesc(project)
+                .orElseThrow(()-> new BusinessLogicException(ExceptionCode.SETTLEMENT_NOT_FOUND));
+
+        // 나노초 뒤 부터 주문 내역 계산
+        LocalDateTime from = latest.getPeriodEnd().plusNanos(1);
+        LocalDateTime to = LocalDateTime.now();
+
+        List<Order> orders = orderService.findByProjectAndCreatedAtBetween(project, from, to,TossPaymentStatus.DONE);
+        return calculateSettlementDto(project, from, to, orders);
+    }
+
+
+
+
+    public void validPurchaseSettlement(Project project, User loginUser){
+        //해당 프로젝트의 주인이 아니라면 정산 처리 못하는 예외 로직 추가
+        projectService.validProjectUser(project.getUser(),loginUser);
+
+        //구매형 전용 예외 처리
+        if (project.getProjectType() != ProjectType.PURCHASE) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_PROJECT_TYPE);
+        }
+    }
+
+
+    private SettlementDetailResponseDto calculateSettlementDto(
+            Project project,
+            LocalDateTime from,
+            LocalDateTime to,
+            List<Order> orders
+    ) {
+        long totalAmount = orders.stream().mapToLong(Order::getPaidAmount).sum();
+        long fee = (long) (totalAmount * 0.1);
+        long payout = totalAmount - fee;
+
+        return SettlementDetailResponseDto.builder()
+                .projectTitle(project.getTitle())
+                .periodStart(from)
+                .periodEnd(to)
+                .totalOrderAmount(totalAmount)
+                .feeAmount(fee)
+                .payoutAmount(payout)
+                .settlementStatus(SettlementStatus.WAITING)
+                .build();
+    }
+
+
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/service/SettlementService.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/service/SettlementService.java
@@ -2,6 +2,7 @@ package com.funding.backend.domain.settlement.service;
 
 import com.funding.backend.domain.order.entity.Order;
 import com.funding.backend.domain.order.service.OrderService;
+import com.funding.backend.domain.pricingPlan.entity.PricingPlan;
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.project.service.ProjectService;
 import com.funding.backend.domain.settlement.dto.response.SettlementDetailResponseDto;
@@ -55,7 +56,6 @@ public class SettlementService {
             //정산 내역이 존재하지 않는다면
             return getFromProjectCreation(project);
         } else {
-
             //정산 내역이 존재한다면
             return getFromLatestSettlement(project, settlementList);
         }
@@ -105,8 +105,11 @@ public class SettlementService {
             LocalDateTime to,
             List<Order> orders
     ) {
+        Long pricingPlan = project.getPricingPlan().getPaymentFee();
+
         long totalAmount = orders.stream().mapToLong(Order::getPaidAmount).sum();
-        long fee = (long) (totalAmount * 0.1);
+        double feeRate = pricingPlan / 100.0;
+        long fee = Math.round(totalAmount * feeRate);
         long payout = totalAmount - fee;
 
         return SettlementDetailResponseDto.builder()
@@ -119,7 +122,5 @@ public class SettlementService {
                 .settlementStatus(SettlementStatus.WAITING)
                 .build();
     }
-
-
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/service/SettlementService.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/service/SettlementService.java
@@ -1,0 +1,4 @@
+package com.funding.backend.domain.settlement.service;
+
+public class SettlementService {
+}

--- a/backend/src/main/java/com/funding/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/funding/backend/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.funding.backend.domain.user.entity;
 import com.funding.backend.domain.alarm.entity.Alarm;
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.role.entity.Role;
+import com.funding.backend.domain.settlement.entity.Settlement;
 import com.funding.backend.enums.UserActive;
 import com.funding.backend.global.auditable.Auditable;
 import jakarta.persistence.CascadeType;
@@ -95,6 +96,9 @@ public class User extends Auditable { // Auditable 상속
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     List<Alarm> alarmList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    List<Settlement>  settlementList = new ArrayList<>();
 
 
 }

--- a/backend/src/main/java/com/funding/backend/enums/SettlementStatus.java
+++ b/backend/src/main/java/com/funding/backend/enums/SettlementStatus.java
@@ -1,0 +1,5 @@
+package com.funding.backend.enums;
+
+public enum SettlementStatus {
+    WAITING, COMPLETED, FAILED
+}

--- a/backend/src/main/java/com/funding/backend/enums/SettlementStatus.java
+++ b/backend/src/main/java/com/funding/backend/enums/SettlementStatus.java
@@ -1,5 +1,7 @@
 package com.funding.backend.enums;
 
 public enum SettlementStatus {
-    WAITING, COMPLETED, FAILED
+    WAITING,
+    COMPLETED,
+    FAILED
 }

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -57,6 +57,10 @@ public enum ExceptionCode {
     INVALID_PROVIDING_METHOD(400, "제공 방식이 유효하지 않습니다."),
     MISMATCHED_PAYMENT_AMOUNT(400, "결제 금액이 맞지 않습니다."),
 
+
+    //정산 예외처리
+    SETTLEMENT_NOT_FOUND(404, "정산 내역이 존재하지 않습니다."),
+
     //구매 카테고리 예외처리
     PURCHASE_CATEGORY_NOT_FOUND(404, "존재하지 않는 구매 프로젝트 카테고리 입니다. "),
 


### PR DESCRIPTION
## 📒 개요

- **정산 기능 구현 (사용자 + 관리자 포함)**
- 프로젝트별 정산 내역 조회, 최근 정산 상태 확인, 정산 미리보기 등 제공

<br>

## 📍 Issue 번호

- closed #266

<br>

## 🛠️ 작업사항

- ✅ **사용자 기능**
  - 특정 구매형 프로젝트에 대한 **정산 내역 상세 조회 API**
  - 정산 내역이 없는 경우에도 **프로젝트 생성일 기준 가상 정산 데이터(PREVIEW 상태)** 제공
  - 사용자 본인이 소유한 **모든 구매형 프로젝트에 대한 정산 요약 목록 API** 구현
    - 최근 정산 상태, 마지막 정산일, 최근 정산금 등 포함

- ✅ **정산 로직**
  - 프로젝트의 `pricingPlan` 기준으로 **정산 수수료율 적용 (ex. 4% → 0.04로 계산)**
  - `TossPaymentStatus.DONE` 상태인 주문만 정산 대상에 포함
  - 정산 금액 계산 로직 → `totalAmount`, `fee`, `payoutAmount`

- ✅ **정산 상태 처리**
  - `SettlementStatus` Enum: `PREVIEW`, `COMPLETED`, `FAILED` 등 설계
  - 정산 내역 존재 여부에 따라 처리 흐름 분리:
    - 존재 시: 마지막 정산 이후 주문으로 정산
    - 미존재 시: 프로젝트 생성일 이후 주문으로 가상 정산 제공

- ✅ **유효성 및 권한 체크**
  - 정산 API 접근 시 **프로젝트 소유자 확인**
  - 후원형 프로젝트 접근 시 `INVALID_PROJECT_TYPE` 예외 처리
  - 존재하지 않는 정산 또는 권한 없는 정산 접근 시 `SETTLEMENT_NOT_FOUND`, `SETTLEMENT_PERMISSION_DENIED` 등 처리

- ✅ **ExceptionCode 정리**
  - `SETTLEMENT_NOT_FOUND`, `SETTLEMENT_ALREADY_COMPLETED`, `SETTLEMENT_ORDER_NOT_FOUND`, `SETTLEMENT_PROJECT_TYPE_INVALID` 등 추가

- ✅ 기타
  - `SettlementDetailResponseDto`, `SettlementProjectSummaryDto` 등 응답 DTO 정리
  - Jackson 직렬화 오류(`No serializer found`) 해결 (`@Getter`, `@JsonInclude`, etc.)

<br>

## 📸 스크린샷(선택)


<img width="557" height="743" alt="스크린샷 2025-07-22 오전 10 38 27" src="https://github.com/user-attachments/assets/d87c6004-670e-4042-a9f6-1f9637dd5dd3" />


