### PR TITLE
[ feat ] 251 :  후원 프로젝트 메인 카테고리별 조회 기능

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/donation/controller/DonationController.java
+++ b/backend/src/main/java/com/funding/backend/domain/donation/controller/DonationController.java
@@ -1,6 +1,7 @@
 package com.funding.backend.domain.donation.controller;
 
 import com.funding.backend.domain.donation.dto.request.DonationUpdateRequestDto;
+import com.funding.backend.domain.donation.dto.response.DonationInfoResponseDto;
 import com.funding.backend.domain.donation.dto.response.DonationListResponseDto;
 import com.funding.backend.domain.donation.dto.response.DonationResponseDto;
 import com.funding.backend.domain.donation.service.DonationService;
@@ -8,8 +9,10 @@ import com.funding.backend.domain.donation.service.DonationProjectService;
 import com.funding.backend.domain.project.dto.request.ProjectCreateRequestDto;
 import com.funding.backend.domain.project.dto.response.ProjectResponseDto;
 import com.funding.backend.domain.project.service.ProjectService;
+import com.funding.backend.enums.ProjectStatus;
 import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -28,6 +31,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -107,6 +111,23 @@ public class DonationController {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(ApiResponse.of(HttpStatus.OK.value(), "내가 생성한 후원형 프로젝트 목록 조회 성공", projects));
+    }
+
+
+    @GetMapping("/category/{categoryId}")
+    @Operation(
+        summary = "후원 프로젝트 메인 카테고리별 리스트 조회",
+        description = "후원 프로젝트 메인 카테고리별 리스트 조회"
+    )
+    public ResponseEntity<ApiResponse<Page<DonationInfoResponseDto>>> getDonationMainCategoryList(
+        @Parameter(description = "카테고리 ID") @PathVariable Long categoryId,
+        @RequestParam ProjectStatus projectStatus,
+        @ParameterObject Pageable pageable
+    ) {
+        Page<DonationInfoResponseDto> response = donationService.getDonationMainCategoryList(categoryId, pageable, projectStatus);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.of(HttpStatus.OK.value(), "후원 프로젝트 메인 카테고리별 조회 성공", response));
     }
 
 

--- a/backend/src/main/java/com/funding/backend/domain/donation/dto/response/DonationInfoResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/donation/dto/response/DonationInfoResponseDto.java
@@ -1,8 +1,12 @@
 package com.funding.backend.domain.donation.dto.response;
 
+import com.funding.backend.domain.donation.entity.Donation;
 import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.projectSubCategory.dto.request.ProjectSubRequestDto;
 import com.funding.backend.enums.ProjectType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
@@ -38,6 +42,9 @@ public class DonationInfoResponseDto {
     @Schema(description = "제작자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
     private String hostProfileImageUrl;
 
+    @Schema(description = "프로젝트 서브카테고리", example = "AI / 자동화 도구")
+    private List<ProjectSubRequestDto> projectSubCategories;
+
     public DonationInfoResponseDto(Project project) {
         this.id = project.getId();
         this.title = project.getTitle();
@@ -49,6 +56,13 @@ public class DonationInfoResponseDto {
         this.hostId = project.getUser().getId();
         this.hostName = project.getUser().getName();
         this.hostProfileImageUrl = project.getUser().getImage();
+        Donation donation = project.getDonation();
+        this.projectSubCategories = donation.getProjectSubCategories().stream()
+            .map(psc -> new ProjectSubRequestDto(
+                psc.getSubjectCategory().getId(),
+                psc.getSubjectCategory().getName()
+            ))
+            .collect(Collectors.toList());
     }
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/donation/dto/response/DonationInfoResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/donation/dto/response/DonationInfoResponseDto.java
@@ -1,0 +1,54 @@
+package com.funding.backend.domain.donation.dto.response;
+
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.enums.ProjectType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class DonationInfoResponseDto {
+
+    @Schema(description = "프로젝트 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "프로젝트 제목", example = "개발자 노션 포트폴리오")
+    private String title;
+
+    @Schema(description = "프로젝트 소개", example = "이 프로젝트는 개발자들의 노션 포트폴리오를 소개합니다.")
+    private String introduce;
+
+    @Schema(description = "프로젝트 썸네일 이미지 URL", example = "https://example.com/thumbnail.jpg")
+    private String projectFirstImage;
+
+    @Schema(description = "프로젝트 타입 (구매/기부)", example = "DONATION")
+    private ProjectType projectType;
+
+    @Schema(description = "프로젝트 좋아요 수", example = "150")
+    private int projectLikeCount;
+
+    @Schema(description = "후원 프로젝트의 후원 수", example = "200")
+    private Long sellingAmount;
+
+    @Schema(description = "제작자 ID", example = "145")
+    private Long hostId;
+
+    @Schema(description = "제작자 이름", example = "홍길동")
+    private String hostName;
+
+    @Schema(description = "제작자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    private String hostProfileImageUrl;
+
+    public DonationInfoResponseDto(Project project) {
+        this.id = project.getId();
+        this.title = project.getTitle();
+        this.introduce = project.getIntroduce();
+        this.projectFirstImage = project.getProjectImage().isEmpty() ? null : project.getProjectImage().getFirst().getImageUrl();
+        this.projectType = project.getProjectType();
+        this.projectLikeCount = project.getLikeList() != null ? project.getLikeList().size() : 0;
+        this.sellingAmount = sellingAmount;
+        this.hostId = project.getUser().getId();
+        this.hostName = project.getUser().getName();
+        this.hostProfileImageUrl = project.getUser().getImage();
+    }
+
+}

--- a/backend/src/main/java/com/funding/backend/domain/donation/entity/Donation.java
+++ b/backend/src/main/java/com/funding/backend/domain/donation/entity/Donation.java
@@ -5,7 +5,6 @@ import com.funding.backend.domain.donationReward.entity.DonationReward;
 import com.funding.backend.domain.mainCategory.entity.MainCategory;
 import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.projectSubCategory.entity.ProjectSubCategory;
-import com.funding.backend.domain.purchaseOption.entity.PurchaseOption;
 import com.funding.backend.global.auditable.Auditable;
 
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/funding/backend/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/repository/ProjectRepository.java
@@ -122,5 +122,22 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     long countByUserId(Long userId);
 
+    @EntityGraph(attributePaths = "donation")
+    @Query("SELECT p FROM Project p WHERE p.user.id = :userId AND p.projectType = :projectType")
+    Page<Project> findByUserIdAndProjectTypeWithDonation(Long userId, ProjectType projectType, Pageable pageable);
+
+    @Query("""
+        SELECT p
+        FROM Project p
+        JOIN p.donation pd
+        WHERE pd.mainCategory.id = :categoryId
+          AND p.projectStatus = :status
+""")
+    Page<Project> findByDonationCategoryAndStatus(
+        @Param("categoryId") Long categoryId,
+        @Param("status") ProjectStatus status,
+        Pageable pageable
+    );
+
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/repository/ProjectRepository.java
@@ -98,15 +98,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     Page<Project> findByUserIdAndProjectType(Long userId, ProjectType projectType, Pageable pageable);
 
 
-    @EntityGraph(attributePaths = "donation")
-    @Query("SELECT p FROM Project p WHERE p.user.id = :userId AND p.projectType = :projectType")
-    Page<Project> findByUserIdAndProjectTypeWithDonation(
-            @Param("userId") Long userId,
-            @Param("projectType") ProjectType projectType,
-            Pageable pageable
-    );
-
-
     @Query("""
                 SELECT p
                 FROM Project p

--- a/backend/src/main/java/com/funding/backend/global/config/YetdaSecurityConfig.java
+++ b/backend/src/main/java/com/funding/backend/global/config/YetdaSecurityConfig.java
@@ -55,6 +55,7 @@ public class YetdaSecurityConfig {
                         //프로젝트 (검색 포함됨)
                         .requestMatchers(HttpMethod.GET, "/api/v1/project/**").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/v1/project/purchase/category/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/api/v1/project/donation/category/**").permitAll()
 
                         //알림
                         .requestMatchers(HttpMethod.POST, "/api/v1/alarm/**").hasAnyRole("ADMIN", "USER")


### PR DESCRIPTION
## 📒 개요
- 후원 프로젝트 메인 카테고리별 조회 기능 추가

<br>

## 📍 Issue 번호
- #251 

> closed #Issue_number

<br>

## 🛠️ 작업사항
- 후원 프로젝트 메인 카테고리별 조회 기능
   - API Endpoints
   -  `GET`  /api/v1/project/donation/category/{categoryId}

<br>

## 📸 스크린샷(선택)
<img width="100%" alt="image" src="https://github.com/user-attachments/assets/1aa07ee2-15e2-425b-93c4-80bee05d4899" />