### PR TITLE
[ feat ] 280 : 일반 사용자 알림 구매

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/alarm/enums/AlarmType.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/enums/AlarmType.java
@@ -7,7 +7,8 @@ public enum AlarmType {
 
 
     //회원 구매 알림
-    PROJECT_PURCHASED("누군가 프로젝트를 구매했습니다");
+    PROJECT_PURCHASED("누군가 프로젝트를 구매했습니다"),
+    PROJECT_PURCHASE_SUCCESS("창작물 구매가 완료되었습니다.");
 
 
     private final String description;

--- a/backend/src/main/java/com/funding/backend/domain/alarm/event/NewPurchaseProjectRequest.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/event/NewPurchaseProjectRequest.java
@@ -1,4 +1,0 @@
-package com.funding.backend.domain.alarm.event;
-
-public class NewPurchaseProjectRequest {
-}

--- a/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewPurchaseProjectContext.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewPurchaseProjectContext.java
@@ -9,10 +9,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class NewPurchaseProjectContext {
-    Long userId;
-    String title;
-    ProjectStatus projectStatus;
-    ProjectType projectType;
-    PricingPlan pricingPlan;
+    public Long userId;
+    public String title;
+    public ProjectStatus projectStatus;
+    public ProjectType projectType;
+    public PricingPlan pricingPlan;
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewPurchaseReceivedContext.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewPurchaseReceivedContext.java
@@ -1,0 +1,34 @@
+package com.funding.backend.domain.alarm.event.context;
+
+
+import com.funding.backend.domain.pricingPlan.entity.PricingPlan;
+import com.funding.backend.enums.ProjectStatus;
+import com.funding.backend.enums.ProjectType;
+import com.funding.backend.global.toss.enums.TossPaymentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NewPurchaseReceivedContext {
+    //구매한 유저의 아이디
+    Long userId;
+
+    //구매한 유저의 닉네임
+    String userName;
+
+    //프로젝트 주인 유저 아이디
+    Long projectUserId;
+
+    //결제 완료 상태
+    TossPaymentStatus tossPaymentStatus;
+
+    String title;
+
+    //총 결제 금액
+    Long totalPaymentAmount;
+
+    //해당 프로젝트에서 구매한 창작물 개수
+    Long orderCount;
+
+}

--- a/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewSuccessPurchaseContext.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewSuccessPurchaseContext.java
@@ -1,0 +1,19 @@
+package com.funding.backend.domain.alarm.event.context;
+
+
+import com.funding.backend.domain.pricingPlan.entity.PricingPlan;
+import com.funding.backend.enums.ProjectStatus;
+import com.funding.backend.enums.ProjectType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NewSuccessPurchaseContext {
+    Long userId;
+    String title;
+    Long projectId;
+    Long orderId;
+    //해당 프로젝트에서 구매한 창작물 개수
+    Long orderCount;
+}

--- a/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewSuccessPurchaseContext.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewSuccessPurchaseContext.java
@@ -1,9 +1,11 @@
 package com.funding.backend.domain.alarm.event.context;
 
 
-import com.funding.backend.domain.pricingPlan.entity.PricingPlan;
+import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.enums.ProjectStatus;
-import com.funding.backend.enums.ProjectType;
+import com.funding.backend.global.toss.enums.OrderStatus;
+import com.funding.backend.global.toss.enums.TossPaymentStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,8 +14,15 @@ import lombok.Getter;
 public class NewSuccessPurchaseContext {
     Long userId;
     String title;
-    Long projectId;
-    Long orderId;
+    //구매형, 후원형
+    ProjectStatus projectStatus;
+
+    //결제 완료 상태
+    TossPaymentStatus tossPaymentStatus;
+
+    //총 결제 금액
+    Long totalPaymentAmount;
+
     //해당 프로젝트에서 구매한 창작물 개수
     Long orderCount;
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewSuccessPurchaseContext.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/event/context/NewSuccessPurchaseContext.java
@@ -12,17 +12,17 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class NewSuccessPurchaseContext {
-    Long userId;
-    String title;
+    public Long userId;
+    public String title;
     //구매형, 후원형
-    ProjectStatus projectStatus;
+    public ProjectStatus projectStatus;
 
     //결제 완료 상태
-    TossPaymentStatus tossPaymentStatus;
+    public TossPaymentStatus tossPaymentStatus;
 
     //총 결제 금액
-    Long totalPaymentAmount;
+    public Long totalPaymentAmount;
 
     //해당 프로젝트에서 구매한 창작물 개수
-    Long orderCount;
+    public Long orderCount;
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/event/listener/AlarmEventListener.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/event/listener/AlarmEventListener.java
@@ -1,6 +1,7 @@
 package com.funding.backend.domain.alarm.event.listener;
 
 import com.funding.backend.domain.alarm.event.context.NewPurchaseProjectContext;
+import com.funding.backend.domain.alarm.event.context.NewSuccessPurchaseContext;
 import com.funding.backend.domain.alarm.service.alert.NewPurchaseProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -19,5 +20,11 @@ public class AlarmEventListener {
         ,event.getPricingPlan());
     }
 
-
+    // 구매 완료 알림 ( 창작물을 구매한 사람에게 )
+    @EventListener
+    public void handleNewPurchaseProjectCreated(NewSuccessPurchaseContext event) {
+        newPurchaseProjectService.notifyCreatePurchaseProject(event.getUserId(),
+                event.getTitle(), event.getProjectStatus(),event.getProjectType()
+                ,event.getPricingPlan());
+    }
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/event/listener/AlarmEventListener.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/event/listener/AlarmEventListener.java
@@ -1,20 +1,26 @@
 package com.funding.backend.domain.alarm.event.listener;
 
 import com.funding.backend.domain.alarm.event.context.NewPurchaseProjectContext;
+import com.funding.backend.domain.alarm.event.context.NewPurchaseReceivedContext;
 import com.funding.backend.domain.alarm.event.context.NewSuccessPurchaseContext;
 import com.funding.backend.domain.alarm.service.alert.NewPurchaseProjectService;
+import com.funding.backend.domain.alarm.service.alert.NewPurchaseReceivedService;
 import com.funding.backend.domain.alarm.service.alert.NewSuccessPurchaseService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class AlarmEventListener {
     private final NewPurchaseProjectService newPurchaseProjectService;
     private final NewSuccessPurchaseService newSuccessPurchaseService;
+    private final NewPurchaseReceivedService newPurchaseReceivedService;
 
-    // 비품 요청 알림
+    // 새로운 프로젝트 생성 알림
     @EventListener
     public void handleNewPurchaseProjectCreated(NewPurchaseProjectContext event) {
         newPurchaseProjectService.notifyCreatePurchaseProject(event.getUserId(),
@@ -25,8 +31,23 @@ public class AlarmEventListener {
     // 구매 완료 알림 ( 창작물을 구매한 사람에게 )
     @EventListener
     public void handleSuccessPurchase(NewSuccessPurchaseContext event) {
-        newSuccessPurchaseService.notifySuccessPurchase(event.getUserId(),
-                event.getTitle(), event.getProjectStatus(),event.getProjectType()
-                ,event.getPricingPlan());
+        try {
+            log.info("✅ [이벤트 시작] 구매자 알림 처리 시작: userId={}", event.getUserId());
+            newSuccessPurchaseService.notifySuccessPurchase(event.getUserId(),
+                    event.getTitle(), event.getProjectStatus(),event.getTossPaymentStatus()
+                    ,event.getTotalPaymentAmount(),event.getOrderCount());
+            // 알림 저장 또는 발송 로직
+        } catch (Exception e) {
+            log.error("❌ [에러 발생] 구매자 알림 처리 중 예외", e);
+        }
+    }
+
+    // 구매 생성 알림 ( 프로젝트 주인에게 구매 알림 )
+    @EventListener
+    public void handlePurchaseReceived(NewPurchaseReceivedContext event) {
+        newPurchaseReceivedService.notifyPurchaseReceived(event.getUserId(),
+                event.getProjectUserId(), event.getUserName(), event.getTitle(),
+                event.getTotalPaymentAmount()
+                ,event.getTossPaymentStatus(),event.getOrderCount());
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/event/listener/AlarmEventListener.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/event/listener/AlarmEventListener.java
@@ -3,6 +3,7 @@ package com.funding.backend.domain.alarm.event.listener;
 import com.funding.backend.domain.alarm.event.context.NewPurchaseProjectContext;
 import com.funding.backend.domain.alarm.event.context.NewSuccessPurchaseContext;
 import com.funding.backend.domain.alarm.service.alert.NewPurchaseProjectService;
+import com.funding.backend.domain.alarm.service.alert.NewSuccessPurchaseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AlarmEventListener {
     private final NewPurchaseProjectService newPurchaseProjectService;
+    private final NewSuccessPurchaseService newSuccessPurchaseService;
 
     // 비품 요청 알림
     @EventListener
@@ -22,8 +24,8 @@ public class AlarmEventListener {
 
     // 구매 완료 알림 ( 창작물을 구매한 사람에게 )
     @EventListener
-    public void handleNewPurchaseProjectCreated(NewSuccessPurchaseContext event) {
-        newPurchaseProjectService.notifyCreatePurchaseProject(event.getUserId(),
+    public void handleSuccessPurchase(NewSuccessPurchaseContext event) {
+        newSuccessPurchaseService.notifySuccessPurchase(event.getUserId(),
                 event.getTitle(), event.getProjectStatus(),event.getProjectType()
                 ,event.getPricingPlan());
     }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/policy/NotificationPolicy.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/policy/NotificationPolicy.java
@@ -19,8 +19,8 @@ public class NotificationPolicy {
 
             );
             case USER -> Arrays.asList(
-                    AlarmType.PROJECT_PURCHASED
-
+                    AlarmType.PROJECT_PURCHASED,
+                    AlarmType.PROJECT_PURCHASE_SUCCESS
 
             );
             default -> Collections.emptyList();

--- a/backend/src/main/java/com/funding/backend/domain/alarm/service/alert/NewPurchaseReceivedService.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/service/alert/NewPurchaseReceivedService.java
@@ -1,62 +1,62 @@
 package com.funding.backend.domain.alarm.service.alert;
 
-
 import com.funding.backend.domain.alarm.dto.request.AlarmDto;
 import com.funding.backend.domain.alarm.enums.AlarmType;
 import com.funding.backend.domain.alarm.event.context.NewPurchaseProjectContext;
+import com.funding.backend.domain.alarm.event.context.NewPurchaseReceivedContext;
 import com.funding.backend.domain.alarm.event.context.NewSuccessPurchaseContext;
 import com.funding.backend.domain.alarm.service.AlarmService;
 import com.funding.backend.domain.alarm.strategy.AlarmStrategy;
 import com.funding.backend.domain.alarm.strategy.factory.AlarmStrategyFactory;
-import com.funding.backend.domain.order.entity.Order;
 import com.funding.backend.domain.pricingPlan.entity.PricingPlan;
-import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.domain.user.service.UserService;
 import com.funding.backend.enums.ProjectStatus;
 import com.funding.backend.enums.ProjectType;
 import com.funding.backend.global.toss.enums.TossPaymentStatus;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class NewSuccessPurchaseService {
+public class NewPurchaseReceivedService {
 
     private final AlarmStrategyFactory alarmStrategyFactory;
     private final AlarmService alarmService;
     private final UserService userService;
 
     @Transactional
-    public void notifySuccessPurchase(Long userId, String title, ProjectStatus projectStatus
-            ,TossPaymentStatus tossPaymentStatus,Long totalPaymentAmount, Long orderCount) {
+    public void notifyPurchaseReceived(Long userId, Long projectUserId, String userName ,
+                                       String title, Long totalPaymentAmount, TossPaymentStatus tossPaymentStatus, Long orderCount) {
+        AlarmStrategy strategy = alarmStrategyFactory.getStrategy(AlarmType.PROJECT_PURCHASED);
 
-        AlarmStrategy strategy = alarmStrategyFactory.getStrategy(AlarmType.PROJECT_PURCHASE_SUCCESS);
-        NewSuccessPurchaseContext context = new NewSuccessPurchaseContext(
+        NewPurchaseReceivedContext context = new NewPurchaseReceivedContext(
                 userId,
-                title,
-                projectStatus,
+                userName,
+                projectUserId,
                 tossPaymentStatus,
+                title,
                 totalPaymentAmount,
                 orderCount
         );
 
-        User user  = userService.findUserById(userId);
+        User user  = userService.findUserById(projectUserId);
 
         if (strategy.shouldTrigger(context)) {
 
             String msg = strategy.generateMessage(context);
-
             alarmService.createNotification(new AlarmDto(
-                    AlarmType.PROJECT_PURCHASE_SUCCESS,
+                    AlarmType.PROJECT_PURCHASED,
                     msg,
                     user.getId()
             ));
         }
 
+
+
     }
+
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/service/alert/NewSuccessPurchaseService.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/service/alert/NewSuccessPurchaseService.java
@@ -8,12 +8,17 @@ import com.funding.backend.domain.alarm.event.context.NewSuccessPurchaseContext;
 import com.funding.backend.domain.alarm.service.AlarmService;
 import com.funding.backend.domain.alarm.strategy.AlarmStrategy;
 import com.funding.backend.domain.alarm.strategy.factory.AlarmStrategyFactory;
+import com.funding.backend.domain.order.entity.Order;
 import com.funding.backend.domain.pricingPlan.entity.PricingPlan;
+import com.funding.backend.domain.project.entity.Project;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.domain.user.service.UserService;
 import com.funding.backend.enums.ProjectStatus;
 import com.funding.backend.enums.ProjectType;
+import com.funding.backend.global.toss.enums.TossPaymentStatus;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,15 +32,17 @@ public class NewSuccessPurchaseService {
     private final UserService userService;
 
     @Transactional
-    public void notifySuccessPurchase(Long userId, String title, ProjectStatus status, ProjectType type, PricingPlan pricingPlan) {
-        AlarmStrategy strategy = alarmStrategyFactory.getStrategy(AlarmType.PROJECT_PURCHASED);
+    public void notifySuccessPurchase(Long userId, String title, ProjectStatus projectStatus
+            ,TossPaymentStatus tossPaymentStatus,Long totalPaymentAmount, Long orderCount) {
 
+        AlarmStrategy strategy = alarmStrategyFactory.getStrategy(AlarmType.PROJECT_PURCHASED);
         NewSuccessPurchaseContext context = new NewSuccessPurchaseContext(
                 userId,
                 title,
-                status,
-                type,
-                pricingPlan
+                projectStatus,
+                tossPaymentStatus,
+                totalPaymentAmount,
+                orderCount
         );
 
         List<User> adminUserList = userService.findAllByAdmin();

--- a/backend/src/main/java/com/funding/backend/domain/alarm/service/alert/NewSuccessPurchaseService.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/service/alert/NewSuccessPurchaseService.java
@@ -1,0 +1,55 @@
+package com.funding.backend.domain.alarm.service.alert;
+
+
+import com.funding.backend.domain.alarm.dto.request.AlarmDto;
+import com.funding.backend.domain.alarm.enums.AlarmType;
+import com.funding.backend.domain.alarm.event.context.NewPurchaseProjectContext;
+import com.funding.backend.domain.alarm.event.context.NewSuccessPurchaseContext;
+import com.funding.backend.domain.alarm.service.AlarmService;
+import com.funding.backend.domain.alarm.strategy.AlarmStrategy;
+import com.funding.backend.domain.alarm.strategy.factory.AlarmStrategyFactory;
+import com.funding.backend.domain.pricingPlan.entity.PricingPlan;
+import com.funding.backend.domain.user.entity.User;
+import com.funding.backend.domain.user.service.UserService;
+import com.funding.backend.enums.ProjectStatus;
+import com.funding.backend.enums.ProjectType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NewSuccessPurchaseService {
+
+    private final AlarmStrategyFactory alarmStrategyFactory;
+    private final AlarmService alarmService;
+    private final UserService userService;
+
+    @Transactional
+    public void notifySuccessPurchase(Long userId, String title, ProjectStatus status, ProjectType type, PricingPlan pricingPlan) {
+        AlarmStrategy strategy = alarmStrategyFactory.getStrategy(AlarmType.PROJECT_PURCHASED);
+
+        NewSuccessPurchaseContext context = new NewSuccessPurchaseContext(
+                userId,
+                title,
+                status,
+                type,
+                pricingPlan
+        );
+
+        List<User> adminUserList = userService.findAllByAdmin();
+        for (User admin : adminUserList) {
+            if (strategy.shouldTrigger(context)) {
+                String msg = strategy.generateMessage(context);
+
+                alarmService.createNotification(new AlarmDto(
+                        AlarmType.PURCHASE_PROJECT_REQUEST,
+                        msg,
+                        admin.getId()
+                ));
+            }
+        }
+
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/alarm/strategy/factory/AlarmStrategyFactory.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/strategy/factory/AlarmStrategyFactory.java
@@ -4,6 +4,7 @@ package com.funding.backend.domain.alarm.strategy.factory;
 import com.funding.backend.domain.alarm.enums.AlarmType;
 import com.funding.backend.domain.alarm.strategy.AlarmStrategy;
 import com.funding.backend.domain.alarm.strategy.strategy.NewPurchaseProjectStrategy;
+import com.funding.backend.domain.alarm.strategy.strategy.NewPurchaseReceivedStrategy;
 import com.funding.backend.domain.alarm.strategy.strategy.NewSuccessPurchaseStrategy;
 import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
@@ -23,7 +24,8 @@ public class AlarmStrategyFactory {
         strategyMap.put(AlarmType.PURCHASE_PROJECT_REQUEST, new NewPurchaseProjectStrategy());
 
         //회원
-        strategyMap.put(AlarmType.PROJECT_PURCHASED, new NewSuccessPurchaseStrategy());
+        strategyMap.put(AlarmType.PROJECT_PURCHASE_SUCCESS, new NewSuccessPurchaseStrategy());
+        strategyMap.put(AlarmType.PROJECT_PURCHASED, new NewPurchaseReceivedStrategy());
     }
 
     public AlarmStrategy getStrategy(AlarmType type) {

--- a/backend/src/main/java/com/funding/backend/domain/alarm/strategy/factory/AlarmStrategyFactory.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/strategy/factory/AlarmStrategyFactory.java
@@ -22,6 +22,7 @@ public class AlarmStrategyFactory {
         strategyMap.put(AlarmType.PURCHASE_PROJECT_REQUEST, new NewPurchaseProjectStrategy());
 
         //회원
+        strategyMap.put(AlarmType.PROJECT_PURCHASED, new NewPurchaseProjectStrategy());
     }
 
     public AlarmStrategy getStrategy(AlarmType type) {

--- a/backend/src/main/java/com/funding/backend/domain/alarm/strategy/factory/AlarmStrategyFactory.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/strategy/factory/AlarmStrategyFactory.java
@@ -4,6 +4,7 @@ package com.funding.backend.domain.alarm.strategy.factory;
 import com.funding.backend.domain.alarm.enums.AlarmType;
 import com.funding.backend.domain.alarm.strategy.AlarmStrategy;
 import com.funding.backend.domain.alarm.strategy.strategy.NewPurchaseProjectStrategy;
+import com.funding.backend.domain.alarm.strategy.strategy.NewSuccessPurchaseStrategy;
 import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
 import jakarta.annotation.PostConstruct;
@@ -22,7 +23,7 @@ public class AlarmStrategyFactory {
         strategyMap.put(AlarmType.PURCHASE_PROJECT_REQUEST, new NewPurchaseProjectStrategy());
 
         //회원
-        strategyMap.put(AlarmType.PROJECT_PURCHASED, new NewPurchaseProjectStrategy());
+        strategyMap.put(AlarmType.PROJECT_PURCHASED, new NewSuccessPurchaseStrategy());
     }
 
     public AlarmStrategy getStrategy(AlarmType type) {

--- a/backend/src/main/java/com/funding/backend/domain/alarm/strategy/strategy/NewPurchaseReceivedStrategy.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/strategy/strategy/NewPurchaseReceivedStrategy.java
@@ -1,19 +1,15 @@
 package com.funding.backend.domain.alarm.strategy.strategy;
 
+import com.funding.backend.domain.alarm.event.context.NewPurchaseReceivedContext;
 import com.funding.backend.domain.alarm.event.context.NewSuccessPurchaseContext;
 import com.funding.backend.domain.alarm.strategy.AlarmStrategy;
-import com.funding.backend.domain.order.entity.Order;
-import com.funding.backend.domain.order.service.OrderService;
 import com.funding.backend.global.toss.enums.TossPaymentStatus;
-import lombok.RequiredArgsConstructor;
 
-
-public class NewSuccessPurchaseStrategy implements AlarmStrategy {
-
+public class NewPurchaseReceivedStrategy implements AlarmStrategy  {
     @Override
     public String generateMessage(Object context) {
-        NewSuccessPurchaseContext project = (NewSuccessPurchaseContext) context;
-        return project.getTitle() + " 프로젝트 창작물에 대한 결제가 완료되었습니다.\n"
+        NewPurchaseReceivedContext project = (NewPurchaseReceivedContext) context;
+        return project.getTitle() + " 프로젝트의 창작물을 " + project.getUserName() + "님이 구매하였습니다.\n"
                 + "구매한 창작물 개수는 " + project.getOrderCount() + "개이며,\n"
                 + "총 결제 금액은 " + project.getTotalPaymentAmount() + "원입니다.";
     }
@@ -21,7 +17,7 @@ public class NewSuccessPurchaseStrategy implements AlarmStrategy {
     @Override
     public boolean shouldTrigger(Object context) {
         //결제가 완료된 주문에서만 trigger 동작
-        NewSuccessPurchaseContext project = (NewSuccessPurchaseContext) context;
+        NewPurchaseReceivedContext project = (NewPurchaseReceivedContext) context;
         return true;
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/strategy/strategy/NewSuccessPurchaseStrategy.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/strategy/strategy/NewSuccessPurchaseStrategy.java
@@ -1,0 +1,21 @@
+package com.funding.backend.domain.alarm.strategy.strategy;
+
+import com.funding.backend.domain.alarm.event.context.NewPurchaseProjectContext;
+import com.funding.backend.domain.alarm.event.context.NewSuccessPurchaseContext;
+import com.funding.backend.domain.alarm.strategy.AlarmStrategy;
+import com.funding.backend.enums.ProjectStatus;
+
+public class NewSuccessPurchaseStrategy implements AlarmStrategy {
+
+    @Override
+    public String generateMessage(Object context) {
+        NewSuccessPurchaseContext project = (NewSuccessPurchaseContext) context;
+        return project.getTitle() + "새 프로젝트가 등록되었습니다. 관리자의 승인을 기다리고 있습니다.";
+    }
+
+    @Override
+    public boolean shouldTrigger(Object context) {
+        NewSuccessPurchaseContext project = (NewSuccessPurchaseContext) context;
+        return project.getProjectStatus().equals(ProjectStatus.UNDER_AUDIT);
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/alarm/strategy/strategy/NewSuccessPurchaseStrategy.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/strategy/strategy/NewSuccessPurchaseStrategy.java
@@ -1,21 +1,27 @@
 package com.funding.backend.domain.alarm.strategy.strategy;
 
-import com.funding.backend.domain.alarm.event.context.NewPurchaseProjectContext;
 import com.funding.backend.domain.alarm.event.context.NewSuccessPurchaseContext;
 import com.funding.backend.domain.alarm.strategy.AlarmStrategy;
-import com.funding.backend.enums.ProjectStatus;
+import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.order.service.OrderService;
+import com.funding.backend.global.toss.enums.TossPaymentStatus;
+import lombok.RequiredArgsConstructor;
+
 
 public class NewSuccessPurchaseStrategy implements AlarmStrategy {
 
     @Override
     public String generateMessage(Object context) {
         NewSuccessPurchaseContext project = (NewSuccessPurchaseContext) context;
-        return project.getTitle() + "새 프로젝트가 등록되었습니다. 관리자의 승인을 기다리고 있습니다.";
+        return project.getTitle() + "해당 프로젝트 창작물에 대한 결제가 완료되었습니다.\n"
+                + "구매한 창작물 개수는 " + project.getOrderCount() + "입니다.\n"
+                +" 구매한 총 금액은" + project.getTotalPaymentAmount() +" 원 입니다.";
     }
 
     @Override
     public boolean shouldTrigger(Object context) {
+        //결제가 완료된 주문에서만 trigger 동작
         NewSuccessPurchaseContext project = (NewSuccessPurchaseContext) context;
-        return project.getProjectStatus().equals(ProjectStatus.UNDER_AUDIT);
+        return project.getTossPaymentStatus().equals(TossPaymentStatus.DONE);
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
@@ -6,7 +6,6 @@ import com.funding.backend.domain.settlement.entity.Settlement;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.enums.ProjectType;
 import com.funding.backend.global.auditable.Auditable;
-import com.funding.backend.global.toss.enums.OrderStatus;
 import com.funding.backend.global.toss.enums.PayType;
 import com.funding.backend.global.toss.enums.TossPaymentStatus;
 import jakarta.persistence.Column;

--- a/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
@@ -26,6 +26,10 @@ public interface OrderRepository extends JpaRepository<Order,Long> {
             Pageable pageable
     );
 
+    @Query("SELECT o FROM Order o JOIN FETCH o.orderOptionList WHERE o.orderId = :orderId")
+    Optional<Order> findByOrderIdWithOptions(String orderId);
+
+
 
     //해당 프로젝트 구매 개수
     @Query("SELECT COUNT(o) FROM Order o WHERE o.project.id = :projectId AND o.orderStatus = 'DONE'")

--- a/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
@@ -34,6 +34,12 @@ public class OrderService {
                 .orElseThrow(()->new BusinessLogicException(ExceptionCode.ORDER_NOT_FOUND));
     }
 
+    public Order findOrderByOrderIdWithOptions(String orderId) {
+        return orderRepository.findByOrderIdWithOptions(orderId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.ORDER_NOT_FOUND));
+    }
+
+
     @Transactional
     public void saveOrder(Order order){
         orderRepository.save(order);

--- a/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
@@ -78,5 +78,10 @@ public class OrderService {
         return orderRepository.findByProjectAndCreatedAtBetweenAndOrderStatus(project,from,to,tossPaymentStatus);
     }
 
+    public Order findOrderById(Long id){
+        return orderRepository.findById(id)
+                .orElseThrow(()-> new BusinessLogicException(ExceptionCode.ORDER_NOT_FOUND));
+    }
+
 
 }

--- a/backend/src/main/java/com/funding/backend/global/config/YetdaSecurityConfig.java
+++ b/backend/src/main/java/com/funding/backend/global/config/YetdaSecurityConfig.java
@@ -105,6 +105,9 @@ public class YetdaSecurityConfig {
                         //Q&A
                         .requestMatchers(HttpMethod.GET, "/api/v1/reviews/**").permitAll()
 
+                        //구매 주문서 생성
+                        .requestMatchers(HttpMethod.POST,"/api/v1/order/purchase/**").hasAnyRole("ADMIN", "USER")
+
 
                         .anyRequest().authenticated()
                 )

--- a/backend/src/main/java/com/funding/backend/global/toss/controller/TossController.java
+++ b/backend/src/main/java/com/funding/backend/global/toss/controller/TossController.java
@@ -2,6 +2,7 @@ package com.funding.backend.global.toss.controller;
 
 import com.funding.backend.domain.order.entity.Order;
 import com.funding.backend.domain.order.service.OrderService;
+import com.funding.backend.enums.ProjectType;
 import com.funding.backend.global.exception.BusinessLogicException;
 import com.funding.backend.global.exception.ExceptionCode;
 import com.funding.backend.global.toss.dto.request.ConfirmPaymentRequestDto;
@@ -24,6 +25,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.ui.Model;
@@ -54,6 +56,7 @@ public class TossController {
     public ResponseEntity<ApiResponse<Void>> confirmPayment(@RequestBody ConfirmPaymentRequestDto dto) {
         try {
             tossService.confirmAndProcessPayment(dto);
+
             return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK.value(), "결제 성공", null));
         } catch (BusinessLogicException e) {
             // 결제 금액 불일치 등의 경우만 삭제 수행
@@ -78,6 +81,17 @@ public class TossController {
                     .body(ApiResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류", null));
         }
     }
+
+//    @PostMapping("/success/alarm/{orderId}")
+//    public ResponseEntity<ApiResponse<Void>> notifyPurchaseSuccess(@PathVariable String orderId) {
+//        tossService.alarmService(orderId);
+//
+//        return ResponseEntity
+//                .status(HttpStatus.OK)
+//                .body(ApiResponse.of(HttpStatus.OK.value(), "알림 생성 완료", null));
+//    }
+
+
 
 
 //

--- a/backend/src/main/java/com/funding/backend/security/jwt/JwtAuthFilter.java
+++ b/backend/src/main/java/com/funding/backend/security/jwt/JwtAuthFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             Long userId = jwtTokenizer.getUserIdFromAccessToken(token);
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
-
+            log.info("JWT Role: {}", user.getRole().getRole().name());
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     user, null, List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().getRole().name()))
             );

--- a/backend/src/main/java/com/funding/backend/security/jwt/JwtTokenizer.java
+++ b/backend/src/main/java/com/funding/backend/security/jwt/JwtTokenizer.java
@@ -11,12 +11,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class JwtTokenizer {
 
     public static final Long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 3;  // 3시간
@@ -75,6 +77,7 @@ public class JwtTokenizer {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
+            log.error("토큰 유효성 검증 실패: {}", e.getMessage());
             return false;
         }
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -135,9 +135,3 @@ springdoc:
   show-actuator: true
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
-
-alarm:
-  timeout: ${ALARM_TIMEOUT}
-
-settlement:
-  day: ${SETTLEMENT_DAY}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -135,3 +135,9 @@ springdoc:
   show-actuator: true
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+alarm:
+  timeout: ${ALARM_TIMEOUT}
+
+settlement:
+  day: ${SETTLEMENT_DAY}


### PR DESCRIPTION
## 📒 개요

결제 성공 시 사용자와 프로젝트 생성자에게 알림이 전송되는 기능 구현

<br>

## 📍 Issue 번호

> closed #이슈번호_여기에

<br>

## 🛠️ 작업사항

- Toss 결제 성공 후 알림 이벤트 발행 로직 구현 (`TossService.alarmService`)
- 알림 전략 (`AlarmStrategy`) 기반 메시지 생성 방식 적용
- `NewSuccessPurchaseStrategy`: 구매자에게 결제 성공 알림 메시지 생성
- `NewPurchaseReceivedStrategy`: 프로젝트 생성자에게 구매 알림 메시지 생성
- 알림 메시지 표현 개선 (구매 수, 결제 금액 등)
- `LazyInitializationException` 방지를 위한 `orderOptionList` fetch join 처리
- 프론트에서 알림 API 호출 시 JWT 쿠키 누락 문제 대응 (`credentials: 'include'` 적용)
- `@Transactional` 추가하여 트랜잭션 내에서 컬렉션 접근 처리

<br>

## 📸 스크린샷(선택)
<img width="1133" height="645" alt="스크린샷 2025-07-23 오전 12 41 18" src="https://github.com/user-attachments/assets/568974d8-a2ba-4844-a75f-596b196c2a28" />


