### PR TITLE
[ feat ] 299 : 사용자 구매 정산 리스트 조회 기능 구현 완료

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
@@ -36,5 +36,4 @@ public class AlarmController {
         return alarmService.createSseConnection();
     }
 
-
 }

--- a/backend/src/main/java/com/funding/backend/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/repository/ProjectRepository.java
@@ -131,4 +131,15 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     );
 
 
+    //프로젝트 타입, 프로젝트 상태에 따른 유저 프로젝트 조회
+    @EntityGraph(attributePaths = "purchase")
+    Page<Project> findByUserIdAndProjectTypeAndProjectStatusIn(
+            Long userId,
+            ProjectType projectType,
+            List<ProjectStatus> projectStatuses,
+            Pageable pageable
+    );
+
+
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
@@ -263,5 +263,17 @@ public class ProjectService {
     public long countProjectsByUser(Long userId) {
         return projectRepository.countByUserId(userId);
     }
+
+    public Page<Project> findByUserIdAndProjectTypeAndProjectStatusIn(Long userId, Pageable pageable
+            ,ProjectType projectType,List<ProjectStatus> projectStatuses){
+        return projectRepository.findByUserIdAndProjectTypeAndProjectStatusIn(
+                userId,
+                projectType,
+                projectStatuses,
+                pageable
+        );
+    }
+
+
 }
 

--- a/backend/src/main/java/com/funding/backend/domain/settlement/controller/SettlementController.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/controller/SettlementController.java
@@ -1,22 +1,28 @@
 package com.funding.backend.domain.settlement.controller;
 
 
+import com.funding.backend.domain.settlement.dto.response.SettlementDetailListResponseDto;
 import com.funding.backend.domain.settlement.dto.response.SettlementDetailResponseDto;
 import com.funding.backend.domain.settlement.service.SettlementService;
 import com.funding.backend.global.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -42,5 +48,19 @@ public class SettlementController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.of(HttpStatus.OK.value(), "정산 상세 조회 성공", response));
     }
+
+    @GetMapping("/purchase/list")
+    @Operation(
+            summary = "사용자의 구매형 프로젝트 정산 리스트 조회",
+            description = "사용자가 자신의 구매형 프로젝트에 대해 가장 최근 정산 정보 리스트를 조회합니다. 후원형 프로젝트는 제외됩니다."
+    )
+    public ResponseEntity<ApiResponse<Page<SettlementDetailListResponseDto>>> getMyPurchaseProjectSettlementList(
+            @ParameterObject Pageable pageable
+    ) {
+        Page<SettlementDetailListResponseDto> response = settlementService.getPurchaseSettlementDetailsListByUser(pageable);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "정산 리스트 조회 성공", response));
+    }
+
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/SettlementDetailListResponseDto.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/dto/response/SettlementDetailListResponseDto.java
@@ -1,0 +1,24 @@
+package com.funding.backend.domain.settlement.dto.response;
+
+import com.funding.backend.enums.ProjectStatus;
+import com.funding.backend.enums.SettlementStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SettlementDetailListResponseDto {
+    private String projectTitle;
+    private LocalDateTime periodStart;
+    private LocalDateTime periodEnd;
+    private Long totalOrderAmount;
+    private Long feeAmount;
+    private Long payoutAmount;
+    private SettlementStatus settlementStatus;
+    private ProjectStatus projectStatus;
+    private String projectImageUrl;
+
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/mapper/SettlementDetailListResponseMapper.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/mapper/SettlementDetailListResponseMapper.java
@@ -1,0 +1,28 @@
+
+package com.funding.backend.domain.settlement.mapper;
+
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.settlement.dto.response.SettlementDetailListResponseDto;
+import com.funding.backend.enums.SettlementStatus;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SettlementDetailListResponseMapper implements SettlementDtoMapper<SettlementDetailListResponseDto> {
+
+    @Override
+    public SettlementDetailListResponseDto map(Project project, LocalDateTime from, LocalDateTime to,
+                                               long totalAmount, long fee, long payout) {
+        return SettlementDetailListResponseDto.builder()
+                .projectTitle(project.getTitle())
+                .periodStart(from)
+                .periodEnd(to)
+                .totalOrderAmount(totalAmount)
+                .feeAmount(fee)
+                .payoutAmount(payout)
+                .settlementStatus(SettlementStatus.WAITING)
+                .projectStatus(project.getProjectStatus())
+                .projectImageUrl(project.getProjectImage().isEmpty() ? null : project.getProjectImage().getFirst().getImageUrl())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/mapper/SettlementDetailResponseMapper.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/mapper/SettlementDetailResponseMapper.java
@@ -1,0 +1,25 @@
+package com.funding.backend.domain.settlement.mapper;
+
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.settlement.dto.response.SettlementDetailResponseDto;
+import com.funding.backend.enums.SettlementStatus;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SettlementDetailResponseMapper implements SettlementDtoMapper<SettlementDetailResponseDto> {
+
+    @Override
+    public SettlementDetailResponseDto map(Project project, LocalDateTime from, LocalDateTime to,
+                                           long totalAmount, long fee, long payout) {
+        return SettlementDetailResponseDto.builder()
+                .projectTitle(project.getTitle())
+                .periodStart(from)
+                .periodEnd(to)
+                .totalOrderAmount(totalAmount)
+                .feeAmount(fee)
+                .payoutAmount(payout)
+                .settlementStatus(SettlementStatus.WAITING)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/mapper/SettlementDtoMapper.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/mapper/SettlementDtoMapper.java
@@ -1,0 +1,8 @@
+package com.funding.backend.domain.settlement.mapper;
+
+import com.funding.backend.domain.project.entity.Project;
+import java.time.LocalDateTime;
+
+public interface SettlementDtoMapper<T> {
+    T map(Project project, LocalDateTime from, LocalDateTime to, long totalAmount, long fee, long payout);
+}


### PR DESCRIPTION
## 📒 개요

사용자 구매형 프로젝트 정산 리스트 조회 기능 구현  
– 각 프로젝트별로 마지막 정산 이후부터 현재까지의 정산 가능 금액, 기간, 수수료 등을 계산하여 리스트 형태로 반환함  
– 프로젝트 상태가 `RECRUITING`, `COMPLETED`인 경우만 정산 대상에 포함

---

## 📍 Issue 번호

> closed #299

---

## 🛠️ 작업사항

- `SettlementService.getPurchaseSettlementDetailsListByUser()` 구현  
- 정산 로직 공통화: `getSettlementPeriodAndCalculate()` + `SettlementDtoMapper` 전략 패턴 적용  
- 정산 리스트용 DTO(`SettlementDetailListResponseDto`) 분리 및 정산 데이터 매핑  
- 구매형 프로젝트만 대상, 정산 내역이 없으면 생성일 기준 계산  
- 프로젝트 상태가 `RECRUITING`, `COMPLETED`인 경우만 포함  
- 주문 상태가 `TossPaymentStatus.DONE`인 건만 정산 대상

---

## 📸 스크린샷(선택)

<img width="1133" height="782" alt="스크린샷 2025-07-23 오전 2 11 17" src="https://github.com/user-attachments/assets/c407e7bd-c97c-40ea-84a5-b1c437506481" />

