### PR TITLE
[ feat ] : 개별알림 / 모든 알림 읽음 처리 구현 완료

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
@@ -62,4 +62,44 @@ public class AlarmController {
                 .body(ApiResponse.of(HttpStatus.OK.value(), "사용자 알림 조회 성공", response));
     }
 
+
+    @PutMapping("/{alarmId}/read")
+    @Operation(
+            summary = "단일 알림 읽음 처리",
+            description = """
+        특정 알림 ID에 해당하는 알림을 읽음 처리합니다.
+        - 사용자는 본인에게 전달된 알림만 읽음 처리할 수 있습니다.
+        - 이미 읽은 알림인 경우에도 성공적으로 처리됩니다.
+    """
+    )
+    public ResponseEntity<ApiResponse<Void>> readAlarm(
+            @PathVariable Long alarmId
+    ) {
+        alarmService.readAlarm(alarmId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "알림 읽음 처리 성공"));
+    }
+
+
+
+    @PutMapping("/user/read")
+    @Operation(
+            summary = "사용자의 모든 알림 읽음 처리",
+            description = """
+            로그인한 사용자의 모든 알림을 일괄적으로 읽음 처리합니다.
+            - 읽지 않은 알림만 대상이 되며, 이미 읽은 알림은 무시됩니다.
+    """
+    )
+    public ResponseEntity<ApiResponse<Void>> readAllUserAlarms() {
+        alarmService.readAllUserAlarms();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "사용자 전체 알림 읽음 처리 성공"));
+    }
+
+
+
+
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/repository/AlarmRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/repository/AlarmRepository.java
@@ -14,6 +14,8 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     Page<Alarm> findAllByUser(User user, Pageable pageable);
 
+    List<Alarm> findByUserAndReadStatus(User user, boolean readStatus);
+
 
 
 }

--- a/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/funding/backend/global/exception/ExceptionCode.java
@@ -110,7 +110,10 @@ public enum ExceptionCode {
     PRICING_PLAN_NOT_FOUND(404, "존재하지 않는 요금제 입니다"),
 
     //알림 예외 처리
-    ALARM_STRATEGY_NOT_FOUND(404, "해당 알림 유형에 대한 전략이 존재하지 않습니다");
+    ALARM_STRATEGY_NOT_FOUND(404, "해당 알림 유형에 대한 전략이 존재하지 않습니다"),
+    ALARM_NOT_FOUND(404, "존재하지 않는 알림입니다."),
+    ALARM_FORBIDDEN(403, "해당 알림에 접근할 권한이 없습니다.");
+
 
     @Getter
     private final int status;


### PR DESCRIPTION
## 📒 개요

개별 알림 및 전체 알림 읽음 처리 기능을 구현했습니다.  
- 사용자는 특정 알림을 읽음 처리할 수 있으며  
- 자신의 모든 알림을 한 번에 읽음 처리할 수 있습니다.



## 📍 Issue 번호

> closed #이슈번호



## 🛠️ 작업사항

- [x] 단일 알림 읽음 처리 API 구현  
  - `PATCH /api/v1/alarm/{alarmId}/read`
  - 본인의 알림만 읽을 수 있도록 권한 검사
- [x] 전체 알림 읽음 처리 API 구현  
  - `PATCH /api/v1/alarm/user/read`
  - 읽지 않은 알림만 대상으로 처리
- [x] 알림 관련 예외 코드 추가
  - `ALARM_NOT_FOUND (404)` : 존재하지 않는 알림
  - `ALARM_FORBIDDEN (403)` : 해당 알림에 접근할 수 없는 경우



## 📸 스크린샷 (선택)

<img width="951" height="651" alt="스크린샷 2025-07-24 오전 11 15 47" src="https://github.com/user-attachments/assets/009d2eb7-c919-4974-8927-77c2a8ec1ebe" />
<img width="951" height="717" alt="스크린샷 2025-07-24 오전 11 15 35" src="https://github.com/user-attachments/assets/d238c417-b71f-4261-8838-e48e9140f663" />

