### PR TITLE
[ feat ] 324 : 단일 알림 전체 알림 삭제 기능

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
@@ -127,6 +127,27 @@ public class AlarmController {
     }
 
 
+    @DeleteMapping("/user")
+    @Operation(
+            summary = "읽음 상태(readStatus)에 따른 알림 삭제",
+            description = """
+            로그인한 사용자의 알림 중, readStatus 조건에 따라 알림을 삭제합니다.
+            - readStatus = true  → 읽은 알림만 삭제
+            - readStatus = false → 읽지 않은 알림만 삭제
+            - readStatus 생략 시 삭제되지 않음 (400 Bad Request 응답 예상)
+        """
+    )
+    public ResponseEntity<ApiResponse<Void>> deleteAlarmsByReadStatus(
+            @RequestParam Boolean readStatus
+    ) {
+        alarmService.deleteAlarmsByReadStatus(readStatus);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "조건부 알림 삭제 성공"));
+    }
+
+
+
 
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
@@ -127,7 +127,7 @@ public class AlarmController {
     }
 
 
-    @DeleteMapping("/user")
+    @DeleteMapping("/user/status")
     @Operation(
             summary = "읽음 상태(readStatus)에 따른 알림 삭제",
             description = """

--- a/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
@@ -98,7 +98,17 @@ public class AlarmController {
                 .body(ApiResponse.of(HttpStatus.OK.value(), "사용자 전체 알림 읽음 처리 성공"));
     }
 
-
+    @DeleteMapping("/{alarmId}")
+    @Operation(
+            summary = "단일 알림 삭제",
+            description = "알림 ID에 해당하는 단일 알림을 삭제합니다. 사용자는 본인에게 전달된 알림만 삭제할 수 있습니다."
+    )
+    public ResponseEntity<ApiResponse<Void>> deleteAlarm(@PathVariable Long alarmId) {
+        alarmService.deleteAlarm(alarmId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "알림 삭제 성공"));
+    }
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
@@ -110,6 +110,23 @@ public class AlarmController {
                 .body(ApiResponse.of(HttpStatus.OK.value(), "알림 삭제 성공"));
     }
 
+    @DeleteMapping("/user")
+    @Operation(
+            summary = "사용자의 모든 알림 삭제",
+            description = """
+            로그인한 사용자의 모든 알림을 삭제합니다.
+            - 읽음 여부와 관계없이 전체 알림이 삭제됩니다.
+            - 사용자의 알림만 삭제되며, 다른 사용자의 알림에는 영향을 주지 않습니다.
+        """
+    )
+    public ResponseEntity<ApiResponse<Void>> deleteAllUserAlarms() {
+        alarmService.deleteAllUserAlarms();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "전체 알림 삭제 성공"));
+    }
+
+
 
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/repository/AlarmRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/repository/AlarmRepository.java
@@ -16,6 +16,8 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     List<Alarm> findByUserAndReadStatus(User user, boolean readStatus);
 
+    void deleteAlarmByUser(User user);
+
 
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/alarm/repository/AlarmRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/repository/AlarmRepository.java
@@ -2,10 +2,13 @@ package com.funding.backend.domain.alarm.repository;
 
 import com.funding.backend.domain.alarm.entity.Alarm;
 import com.funding.backend.domain.user.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
@@ -16,7 +19,15 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     List<Alarm> findByUserAndReadStatus(User user, boolean readStatus);
 
-    void deleteAlarmByUser(User user);
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Alarm a WHERE a.user = :user")
+    void deleteAlarmByUser(@Param("user") User user);
+
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Alarm a WHERE a.user = :user AND a.readStatus = :readStatus")
+    void deleteAlarmByUserAndReadStatus(@Param("user") User user, @Param("readStatus") boolean readStatus);
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/alarm/service/AlarmService.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/service/AlarmService.java
@@ -104,8 +104,7 @@ public class AlarmService {
 
     @Transactional
     public void readAlarm(Long alarmId) {
-        Alarm alarm = alarmRepository.findById(alarmId)
-                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.ALARM_NOT_FOUND));
+        Alarm alarm = findAlarmById(alarmId);
         //유저 식별 검사
         validUser(alarm);
 
@@ -127,6 +126,12 @@ public class AlarmService {
 
     }
 
+    public void deleteAlarm(Long alarmId){
+        Alarm alarm = findAlarmById(alarmId);
+        validUser(alarm);
+        alarmRepository.delete(alarm);
+    }
+
 
 
     public void validUser(Alarm alarm){
@@ -135,6 +140,13 @@ public class AlarmService {
             throw new BusinessLogicException(ExceptionCode.ALARM_FORBIDDEN);
         }
     }
+
+    public Alarm findAlarmById(Long alarmId){
+        return alarmRepository.findById(alarmId)
+                .orElseThrow(()-> new BusinessLogicException(ExceptionCode.ALARM_NOT_FOUND));
+    }
+
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/alarm/service/AlarmService.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/service/AlarmService.java
@@ -125,16 +125,24 @@ public class AlarmService {
         }
 
     }
-
+    @Transactional
     public void deleteAlarm(Long alarmId){
         Alarm alarm = findAlarmById(alarmId);
         validUser(alarm);
         alarmRepository.delete(alarm);
     }
 
+    @Transactional
     public void deleteAllUserAlarms(){
         User user = userService.findUserById(tokenService.getUserIdFromAccessToken());
         alarmRepository.deleteAlarmByUser(user);
+    }
+
+    @Transactional
+    public void deleteAlarmsByReadStatus(boolean readStatus){
+        User user = userService.findUserById(tokenService.getUserIdFromAccessToken());
+        alarmRepository.deleteAlarmByUserAndReadStatus(user, readStatus);
+
     }
 
 

--- a/backend/src/main/java/com/funding/backend/domain/alarm/service/AlarmService.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/service/AlarmService.java
@@ -132,6 +132,11 @@ public class AlarmService {
         alarmRepository.delete(alarm);
     }
 
+    public void deleteAllUserAlarms(){
+        User user = userService.findUserById(tokenService.getUserIdFromAccessToken());
+        alarmRepository.deleteAlarmByUser(user);
+    }
+
 
 
     public void validUser(Alarm alarm){


### PR DESCRIPTION
## 📒 개요

단일 알림 삭제, 전체 알림 삭제, 읽음 상태(readStatus)에 따른 알림 삭제 기능을 구현했습니다.  
API 충돌 문제도 함께 수정하여 하나의 조건부 API로 통합하였습니다.




## 📍 Issue 번호

> closed #324



## 🛠️ 작업사항

- [x] 단일 알림 삭제 기능 구현 (`DELETE /api/v1/alarm/{alarmId}`)
- [x] 사용자 전체 알림 삭제 기능 구현 (`DELETE /api/v1/alarm/user`)
- [x] 읽음 상태(readStatus)에 따른 알림 조건부 삭제 기능 구현  
  - `DELETE /api/v1/alarm/user?readStatus=true` → 읽은 알림 삭제  
  - `DELETE /api/v1/alarm/user?readStatus=false` → 안 읽은 알림 삭제
- [x] API 중복(@DeleteMapping("/user")) 충돌 문제 수정




---

## 🔍 기타 참고사항

- `@Modifying(clearAutomatically = true)` 적용하여 영속성 컨텍스트 동기화 문제 방지
- 조건 분기로 하나의 API에서 전체 삭제/조건 삭제 통합 처리
