### PR TITLE
[ feat ] 303 : 월 1회 정산 기능 구현 완료

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
+++ b/backend/src/main/java/com/funding/backend/domain/alarm/controller/AlarmController.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -145,9 +146,6 @@ public class AlarmController {
                 .status(HttpStatus.OK)
                 .body(ApiResponse.of(HttpStatus.OK.value(), "조건부 알림 삭제 성공"));
     }
-
-
-
 
 
 }

--- a/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
@@ -20,6 +20,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -28,6 +29,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Table(name = "orders")
@@ -64,6 +66,10 @@ public class Order extends Auditable {
 
 	@Column(nullable = false)
 	private String customerName;
+
+
+	@Column(name = "purchase_success_time", updatable = false)
+	private LocalDateTime purchaseSuccessTime;
 
 	@Column(nullable = false)
 	private String orderName;

--- a/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
@@ -53,6 +53,21 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             TossPaymentStatus orderStatus
     );
 
+    List<Order> findByPurchaseSuccessTimeBetweenAndOrderStatusAndSettlementIsNull(
+            LocalDateTime from,
+            LocalDateTime to,
+            TossPaymentStatus orderStatus
+    );
+
+    List<Order> findByPurchaseSuccessTimeBetweenAndOrderStatusAndProjectTypeAndSettlementIsNull(
+            LocalDateTime start,
+            LocalDateTime end,
+            TossPaymentStatus orderStatus,
+            ProjectType projectType
+    );
+
+
+
     long countDistinctByUser_IdAndProjectType(
             @Param("userId") Long userId,
             @Param("projectType") ProjectType projectType

--- a/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
@@ -5,6 +5,7 @@ import com.funding.backend.domain.order.dto.response.OrderResponseDto;
 import com.funding.backend.domain.order.entity.Order;
 import com.funding.backend.domain.order.repository.OrderRepository;
 import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.settlement.factory.SettlementPeriod;
 import com.funding.backend.domain.user.entity.User;
 import com.funding.backend.domain.user.service.UserService;
 import com.funding.backend.enums.ProjectType;
@@ -91,6 +92,18 @@ public class OrderService {
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.ORDER_NOT_FOUND));
     }
 
+
+    public List<Order> findBySettlementPeriod(SettlementPeriod period, ProjectType projectType,TossPaymentStatus tossPaymentStatus) {
+        return orderRepository.findByPurchaseSuccessTimeBetweenAndOrderStatusAndProjectTypeAndSettlementIsNull(
+                period.getStart(),
+                period.getEnd(),
+                tossPaymentStatus,
+                projectType
+        );
+    }
+
+
+
     // 관리자용: 사용자·타입(PURCHASE/DONATION)별 주문한 프로젝트 수
     public long countDistinctByUserAndType(Long userId, ProjectType type) {
         return orderRepository.countDistinctByUser_IdAndProjectType(userId, type);
@@ -100,5 +113,10 @@ public class OrderService {
     public long sumPaidByUserAndType(Long userId, ProjectType type) {
         Long sum = orderRepository.sumPaidAmountByUserIdAndProjectType(userId, type);
         return (sum != null ? sum : 0L);
+    }
+
+    @Transactional
+    public void saveOrderList(List<Order> orderList){
+        orderRepository.saveAll(orderList);
     }
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/factory/SettlementFactory.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/factory/SettlementFactory.java
@@ -1,0 +1,30 @@
+package com.funding.backend.domain.settlement.factory;
+
+import com.funding.backend.domain.order.entity.Order;
+import com.funding.backend.domain.project.entity.Project;
+import com.funding.backend.domain.settlement.entity.Settlement;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SettlementFactory {
+    public Settlement create(Project project, List<Order> orders, SettlementPeriod period) {
+        long total = orders.stream().mapToLong(Order::getPaidAmount).sum();
+        double feeRate = project.getPricingPlan().getPlatformFee() / 100.0;
+        long fee = Math.round(total * feeRate);
+        long payout = total - fee;
+
+        return Settlement.builder()
+                .project(project)
+                .totalOrderAmount(total)
+                .feeAmount(fee)
+                .payoutAmount(payout)
+                .periodStart(period.getStart())
+                .periodEnd(period.getEnd())
+                .settledAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/factory/SettlementPeriod.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/factory/SettlementPeriod.java
@@ -1,0 +1,24 @@
+package com.funding.backend.domain.settlement.factory;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+
+@Getter
+public class SettlementPeriod {
+
+    private final LocalDateTime start;
+    private final LocalDateTime end;
+    private final YearMonth yearMonth;
+
+    public SettlementPeriod(LocalDateTime start, LocalDateTime end, YearMonth yearMonth) {
+        this.start = start;
+        this.end = end;
+        this.yearMonth = yearMonth;
+    }
+
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/factory/SettlementPeriodFactory.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/factory/SettlementPeriodFactory.java
@@ -1,0 +1,25 @@
+package com.funding.backend.domain.settlement.factory;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SettlementPeriodFactory {
+
+    private final SettlementProperties props;
+
+    public SettlementPeriod create(YearMonth currentMonth) {
+        LocalDateTime start = currentMonth.minusMonths(1)
+                .atDay(props.getDay())
+                .atTime(props.getHour(), props.getMinute());
+
+        LocalDateTime end = currentMonth
+                .atDay(props.getDay())
+                .atTime(props.getHour(), props.getMinute());
+
+        return new SettlementPeriod(start, end, currentMonth);
+    }
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/factory/SettlementProperties.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/factory/SettlementProperties.java
@@ -1,0 +1,16 @@
+package com.funding.backend.domain.settlement.factory;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "settlement")
+@Getter
+@Setter
+public class SettlementProperties {
+    private int day;
+    private int hour;
+    private int minute;
+}

--- a/backend/src/main/java/com/funding/backend/domain/settlement/repository/SettlementRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/repository/SettlementRepository.java
@@ -45,4 +45,5 @@ public interface SettlementRepository extends JpaRepository<Settlement, Long> {
 
 
 
+
 }

--- a/backend/src/main/java/com/funding/backend/domain/settlement/schedule/SettlementScheduler.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/schedule/SettlementScheduler.java
@@ -1,0 +1,27 @@
+package com.funding.backend.domain.settlement.schedule;
+
+
+import com.funding.backend.domain.settlement.service.SettlementService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class SettlementScheduler {
+
+
+    private final SettlementService settlementService;
+
+    @Scheduled(cron = "0 0 3 20 * ?") //// 매월 20일 03:00 실행
+    public void settleMonthlyProjects() {
+        log.info("[정산 스케줄러] 월별 정산 시작");
+        settlementService.executeMonthlyPurchaseSettlement();
+        log.info("[정산 스케줄러] 월별 정산 완료");
+    }
+}
+
+

--- a/backend/src/main/java/com/funding/backend/global/toss/controller/TossController.java
+++ b/backend/src/main/java/com/funding/backend/global/toss/controller/TossController.java
@@ -56,7 +56,6 @@ public class TossController {
     public ResponseEntity<ApiResponse<Void>> confirmPayment(@RequestBody ConfirmPaymentRequestDto dto) {
         try {
             tossService.confirmAndProcessPayment(dto);
-
             return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK.value(), "결제 성공", null));
         } catch (BusinessLogicException e) {
             // 결제 금액 불일치 등의 경우만 삭제 수행

--- a/backend/src/main/java/com/funding/backend/global/toss/service/TossService.java
+++ b/backend/src/main/java/com/funding/backend/global/toss/service/TossService.java
@@ -18,6 +18,7 @@ import com.funding.backend.global.toss.dto.response.TossPaymentsResponseDto;
 import com.funding.backend.global.toss.enums.TossPaymentStatus;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -97,6 +98,7 @@ public class TossService {
             order.setPayType(tossRes.getMethod());
             order.setOrderStatus(tossRes.getStatus());
             order.setPaymentKey(dto.getPaymentKey());
+            order.setPurchaseSuccessTime(LocalDateTime.now());
             orderService.saveOrder(order); // 영속성 보장 확인
             alarmService(order.getOrderId());
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -141,3 +141,5 @@ alarm:
 
 settlement:
   day: ${SETTLEMENT_DAY}
+  hour: ${SETTLEMENT_TIME}
+  minute: ${SETTLEMENT_MINUTE}


### PR DESCRIPTION
# [ feat ] 303 : 월 1회 정산 기능 구현 완료

## 📒 개요

월 1회 정해진 날짜(기본: 매월 20일)에 프로젝트별 주문 데이터를 바탕으로 정산 데이터를 생성하는 기능을 구현했습니다.  
정산 대상은 **결제 완료된 구매형 프로젝트 주문**이며, 정산 시 수수료를 제외한 금액이 창작자에게 지급됩니다.

---

## 📍 Issue 번호

> closed #303

---

## 🛠️ 작업사항

- 월 1회 실행되는 스케줄러(`@Scheduled`) 기반 정산 기능 구현  
- 정산 대상 기간 계산을 위한 `SettlementPeriodFactory` 및 VO 클래스 생성  
- 주문 데이터를 프로젝트 기준으로 그룹핑 후 정산 생성
- 수수료율 기반 정산 금액 계산 (총 결제 금액 - 플랫폼 수수료)
- 정산 내역(`Settlement`) 저장 및 관련 주문서 연결 처리
- 중복 정산 방지를 위해 `settlement_id`가 null인 주문만 대상으로 필터링
- 정산에 필요한 기준 시각(`day`, `hour`, `minute`)을 `.yml` + 환경변수 기반으로 외부 설정 가능

---

## 📸 스크린샷(선택)


