### PR TITLE
[ feat ] : 모든 프로젝트 정산 상태 조회, 구매 내역이 없으면 조회에서 제외

### DIFF
--- a/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/entity/Order.java
@@ -68,7 +68,7 @@ public class Order extends Auditable {
 	private String customerName;
 
 
-	@Column(name = "purchase_success_time", updatable = false)
+	@Column(name = "purchase_success_time")
 	private LocalDateTime purchaseSuccessTime;
 
 	@Column(nullable = false)

--- a/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/repository/OrderRepository.java
@@ -67,6 +67,26 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             ProjectType projectType
     );
 
+    Page<Order> findByPurchaseSuccessTimeBetweenAndOrderStatusAndProjectTypeAndSettlementIsNull(
+            LocalDateTime start,
+            LocalDateTime end,
+            TossPaymentStatus orderStatus,
+            ProjectType projectType,
+            Pageable pageable
+    );
+
+
+    List<Order> findByProjectAndPurchaseSuccessTimeBetweenAndOrderStatusAndSettlementIsNull(
+            Project project,
+            LocalDateTime start,
+            LocalDateTime end,
+            TossPaymentStatus status
+    );
+
+
+
+
+
 
 
     long countDistinctByUser_IdAndProjectType(

--- a/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/funding/backend/domain/order/service/OrderService.java
@@ -84,7 +84,7 @@ public class OrderService {
     //프로젝트 당 특정 기간동안 생성된 주문 확인 ( 주문 완료 된 것만)
     public List<Order> findByProjectAndCreatedAtBetween(Project project, LocalDateTime from, LocalDateTime to,
                                                         TossPaymentStatus tossPaymentStatus) {
-        return orderRepository.findByProjectAndCreatedAtBetweenAndOrderStatus(project, from, to, tossPaymentStatus);
+        return orderRepository.findByProjectAndPurchaseSuccessTimeBetweenAndOrderStatusAndSettlementIsNull(project, from, to, tossPaymentStatus);
     }
 
     public Order findOrderById(Long id) {
@@ -101,6 +101,10 @@ public class OrderService {
                 projectType
         );
     }
+
+
+
+
 
 
 

--- a/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/funding/backend/domain/project/service/ProjectService.java
@@ -201,6 +201,12 @@ public class ProjectService {
         return projectRepository.findByTypeAndStatuses(type, statuses, pageable).map(AuditProjectResponseDto::new);
     }
 
+    public Page<Project> findProjectsByTypeAndStatusPage(ProjectType type, List<ProjectStatus> statuses,
+                                                                     Pageable pageable) {
+        return projectRepository.findByTypeAndStatuses(type, statuses, pageable);
+    }
+
+
     @Transactional
     public AuditProjectResponseDto updateProjectStatus(Long projectId, ProjectStatus status) {
         Project project = findProjectById(projectId);

--- a/backend/src/main/java/com/funding/backend/domain/settlement/controller/AdminSettlementController.java
+++ b/backend/src/main/java/com/funding/backend/domain/settlement/controller/AdminSettlementController.java
@@ -49,29 +49,21 @@ public class AdminSettlementController {
     }
 
 
-    //전체 프로젝트 정산 현황
-//    @GetMapping("/purchase/summary/list")
-//    @Operation(
-//            summary = "모든 구매형 프로젝트 정산 현황 목록 조회 (관리자)",
-//            description = "관리자가 특정 연월에 대해 창작자별 프로젝트 정산 현황 리스트를 조회합니다."
-//    )
-//    @PreAuthorize("hasAnyRole('ADMIN')")
-//    public ResponseEntity<ApiResponse<Page<SettlementProjectSummaryAdminResponseDto>>> getMonthlyPurchaseSettlementSummaryList(
-//            @RequestParam("yearMonth") @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
-//            @ParameterObject Pageable pageable
-//    ) {
-//        Page<SettlementProjectSummaryAdminResponseDto> response = settlementService.getMonthlyPurchaseSettlementSummaryList(yearMonth, pageable);
-//        return ResponseEntity.status(HttpStatus.OK)
-//                .body(ApiResponse.of(HttpStatus.OK.value(), "정산 현황 리스트 조회 성공", response));
-//    }
-//
-
-
-
-
-
-
-
+//    전체 프로젝트 정산 현황
+    @GetMapping("/purchase/summary/list")
+    @Operation(
+            summary = "모든 구매형 프로젝트 정산 현황 목록 조회 (관리자)",
+            description = "관리자가 특정 연월에 대해 창작자별 프로젝트 정산 현황 리스트를 조회합니다."
+    )
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Page<SettlementProjectSummaryAdminResponseDto>>> getMonthlyPurchaseSettlementSummaryList(
+            @RequestParam("yearMonth") @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
+            @ParameterObject Pageable pageable
+    ) {
+        Page<SettlementProjectSummaryAdminResponseDto> response = settlementService.getMonthlyPurchaseSettlementSummaryListForAdmin(yearMonth, pageable);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK.value(), "정산 현황 리스트 조회 성공", response));
+    }
 
 
 


### PR DESCRIPTION
## 📒 개요

관리자가 구매형 프로젝트들의 월별 정산 상태를 확인할 수 있는 기능을 구현했습니다.  
정산 대상은 프로젝트 상태가 `RECRUITING` 등 지정된 상태이고, 해당 월 내 `결제 완료(DONE)`된 주문 내역이 존재하는 프로젝트만 포함됩니다.

## 📍 Issue 번호

> closed #335

## 🛠️ 작업사항

- `/api/v1/settlement/admin/purchase/summary/list` API 구현
- 특정 연월(`yearMonth`) 기준으로 프로젝트별 정산 금액 요약 조회 기능 추가
- `RECRUITING` 상태의 구매형 프로젝트만 대상
- 해당 기간 내 `TossPaymentStatus.DONE` 주문이 하나라도 있어야 포함됨
- 주문 정보 기반으로 다음 항목 계산:
  - `totalOrderAmount` : 총 주문 금액
  - `feeAmount` : 수수료
  - `payoutAmount` : 실제 지급 금액
- 프로젝트 및 창작자 관련 정보 포함:
  - 창작자 이름, 가입일
  - 프로젝트 이름, 생성일, 소개
  - 창작자 계좌 정보
- `PageImpl`을 활용한 페이징 처리

## 📸 스크린샷(선택)

> 필요 시 실제 조회 결과 
<img width="972" height="732" alt="스크린샷 2025-07-27 오후 7 27 11" src="https://github.com/user-attachments/assets/7c3b7ffe-0cb2-4235-8b5e-379da9482972" />
예시나 콘솔 로그 첨부



